### PR TITLE
fix: increase status bar pet size

### DIFF
--- a/ClaudePet/MenuBarView.swift
+++ b/ClaudePet/MenuBarView.swift
@@ -19,7 +19,7 @@ struct MenuBarView: View {
                 if mode == .imageOnly || mode == .both {
                     AnimatedPetView(
                         stage: petManager.petLevel,
-                        size: 16,
+                        size: 19,
                         fps: 8,
                         fallbackEmoji: petManager.emoji,
                         useTemplateRendering: true


### PR DESCRIPTION
## Summary
- increase the displayed status bar pet size so it sits closer to RunCat's menu bar presence
- keep the restored line-art sprite style and current animation behavior intact
- verify the app still builds successfully with the installed Xcode app

## Testing
- built successfully with /Applications/Xcode.app via xcodebuild

Closes #15