### PR TITLE
[codex] Increase status bar pet size again

### DIFF
--- a/ClaudePet/MenuBarView.swift
+++ b/ClaudePet/MenuBarView.swift
@@ -19,7 +19,7 @@ struct MenuBarView: View {
                 if mode == .imageOnly || mode == .both {
                     AnimatedPetView(
                         stage: petManager.petLevel,
-                        size: 20,
+                        size: 30,
                         fps: 8,
                         fallbackEmoji: petManager.emoji,
                         useTemplateRendering: true


### PR DESCRIPTION
## Summary
- increase the menu bar pet display size from 20pt to 30pt
- target a roughly 1.5x larger on-screen feel compared with the previous version
- keep the restored line-art sprite assets and current 5-frame animation loop unchanged

## Why
The line-art quality was in a good place, but the pet still looked undersized next to other menu bar icons. This update focuses only on the visual size so the pet reads more like a primary status item.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData build`
