### PR TITLE
feat: 메뉴바 캐릭터를 픽셀아트 이미지로 전환

### DIFF
--- a/ClaudePet/MenuBarView.swift
+++ b/ClaudePet/MenuBarView.swift
@@ -17,13 +17,15 @@ struct MenuBarView: View {
             } else {
                 let mode = petManager.menuBarDisplayMode
                 if mode == .imageOnly || mode == .both {
-                    AnimatedPetView(
-                        stage: petManager.petLevel,
-                        size: 30,
-                        fps: 8,
-                        fallbackEmoji: petManager.emoji,
-                        useTemplateRendering: true
-                    )
+                    let name = "pet_stage1_\(petManager.menuBarFrame)"
+                    if NSImage(named: name) != nil {
+                        Image(name)
+                            .interpolation(.none)
+                            .resizable()
+                            .frame(width: 22, height: 22)
+                    } else {
+                        Text(petManager.emoji).font(.system(size: 14))
+                    }
                 }
                 if (mode == .usageOnly || mode == .both), let session = petManager.fiveHour {
                     Text("\(Int(session.utilization))%")

--- a/ClaudePet/PetManager.swift
+++ b/ClaudePet/PetManager.swift
@@ -164,6 +164,9 @@ final class PetManager: ObservableObject {
     @Published var dailyUsage: [Date: Int] = [:]
     @Published var isLoadingJournal = false
     @Published var monthlyTokens: Int = 0
+    /// Frame index for menu bar animation — driven by a dedicated 8fps task so it
+    /// works reliably in MenuBarExtra label where .task lifecycle is unreliable.
+    @Published var menuBarFrame: Int = 0
 
     @Published var petType: PetType {
         didSet { UserDefaults.standard.set(petType.rawValue, forKey: "selectedPetType") }
@@ -280,6 +283,7 @@ final class PetManager: ObservableObject {
     }
 
     private var pollTask: Task<Void, Never>?
+    private var menuBarAnimTask: Task<Void, Never>?
     private var isFetching = false              // guard against concurrent fetches
     private var didSendThresholdAlert = false
     private var rateLimitBackoff: Double = 60   // seconds; doubles on each 429, resets on success
@@ -300,10 +304,14 @@ final class PetManager: ObservableObject {
         notificationThreshold = UserDefaults.standard.object(forKey: "notificationThreshold") as? Double ?? 0.8
         isInitialized = true
         startPolling()
+        startMenuBarAnimation()
         loadJournal()
     }
 
-    deinit { pollTask?.cancel() }
+    deinit {
+        pollTask?.cancel()
+        menuBarAnimTask?.cancel()
+    }
 
     func loadJournal() {
         isLoadingJournal = true
@@ -315,6 +323,22 @@ final class PetManager: ObservableObject {
             dailyUsage    = usage
             monthlyTokens = monthly
             isLoadingJournal = false
+        }
+    }
+
+    // MARK: - Menu Bar Animation
+
+    /// Drives menuBarFrame at 8fps independently of the view lifecycle,
+    /// so animation works in MenuBarExtra label where .task is unreliable.
+    private func startMenuBarAnimation() {
+        // Frame count mirrors AnimatedPetView.defaultFrameCounts[1]
+        let frameCount = 5
+        menuBarAnimTask?.cancel()
+        menuBarAnimTask = Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(1.0 / 8.0))
+                menuBarFrame = (menuBarFrame + 1) % frameCount
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- `PetManager`에 `menuBarFrame` 프로퍼티와 전용 8fps 타이머 Task 추가
- `MenuBarView`에서 `AnimatedPetView(.task 기반)` 제거 → `petManager.menuBarFrame`으로 이미지 직접 교체
- 원본 픽셀아트 컬러 그대로 표시, 에셋 없을 경우 이모지 폴백 유지

## 배경
`MenuBarExtra` label 컨텍스트에서 SwiftUI `.task`는 라이프사이클이 불안정해 애니메이션이 멈추는 문제가 있음.
PetManager에서 프레임을 `@Published`로 발행하면 뷰 렌더링과 무관하게 안정적으로 구동됨.

## Test plan
- [ ] 앱 실행 후 상태바에 물범 픽셀아트 애니메이션 확인
- [ ] 에러 상태(⚠️)에서도 정상 표시 확인
- [ ] imageOnly / both / usageOnly 모드 전환 확인
- [ ] 데이터 없는 상태에서 이모지 폴백 확인

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)