### PR TITLE
fix: 설정 메뉴바 미리보기를 실제 물범 픽셀아트로 교체

### DIFF
--- a/ClaudePet/SettingsView.swift
+++ b/ClaudePet/SettingsView.swift
@@ -116,8 +116,10 @@ struct SettingsView: View {
         let mode = petManager.menuBarDisplayMode
         HStack(spacing: 4) {
             if mode == .imageOnly || mode == .both {
-                Text(petManager.emoji)
-                    .font(.system(size: 13))
+                Image("pet_stage1_0")
+                    .interpolation(.none)
+                    .resizable()
+                    .frame(width: 22, height: 22)
             }
             if mode == .usageOnly || mode == .both {
                 Text(petManager.fiveHour.map { "\(Int($0.utilization))%" } ?? "0%")


### PR DESCRIPTION
## Summary
- 설정 > Menu bar 섹션의 미리보기 이모지(🐣)를 `pet_stage1_0` 픽셀아트 이미지로 교체
- 선택한 모드에 따라 올바르게 표시: Icon only / Both → 이미지, Usage only → 텍스트만

## Test plan
- [ ] Icon only → 물범 이미지만 표시
- [ ] Usage only → 사용량 텍스트만 표시
- [ ] Both → 물범 이미지 + 사용량 텍스트 함께 표시

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)