### PR TITLE
fix: make resetsAt optional to handle null API response

### DIFF
--- a/ClaudePet/PetManager.swift
+++ b/ClaudePet/PetManager.swift
@@ -125,7 +125,8 @@ enum SessionMood {
 struct UsageQuota: Decodable {
     /// 0–100 percent
     let utilization: Double
-    let resetsAt: Date
+    /// nil when API omits or nulls the field (e.g. immediately after a reset)
+    let resetsAt: Date?
 
     /// 0.0–1.0 for progress bars / stage logic
     var percent: Double { min(utilization / 100.0, 1.0) }
@@ -367,8 +368,10 @@ final class PetManager: ObservableObject {
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
 
+        var responseData: Data?
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
+            responseData = data
 
             guard let http = response as? HTTPURLResponse else {
                 throw URLError(.badServerResponse)
@@ -399,9 +402,13 @@ final class PetManager: ObservableObject {
                 errorMessage = "API error \(http.statusCode)"
             }
         } catch let error as DecodingError {
-            // JSON shape mismatch — log and surface clearly
+            // JSON shape mismatch — log raw body and surface clearly
             errorMessage = "Unexpected API response.\nCheck app update."
             print("[ClaudePet] Decode error: \(error)")
+            if let data = responseData,
+               let raw = try? JSONSerialization.jsonObject(with: data) {
+                print("[ClaudePet] Raw body: \(raw)")
+            }
         } catch {
             errorMessage = error.localizedDescription
         }


### PR DESCRIPTION
## Summary
- `UsageQuota.resetsAt` was `Date` (non-optional), causing a `DecodingError` crash when the API returns `null` for `resets_at` (e.g. immediately after a session reset)
- Changed `resetsAt` to `Date?` so null values are gracefully handled
- Fixed the `DecodingError` catch block to log the raw response body using the already-captured `responseData` variable (was incorrectly trying to re-fetch the URL)

Closes #30

## Test plan
- [ ] Build and run the app
- [ ] Verify no "Unexpected API response" error on normal usage
- [ ] Confirm `resetsAt`-based UI (reset timer) still displays when value is present and hides gracefully when nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)