### PR TITLE
fix: render cat artwork in pet tab

### DIFF
--- a/ClaudePet/PetManager.swift
+++ b/ClaudePet/PetManager.swift
@@ -225,6 +225,13 @@ final class PetManager: ObservableObject {
         }
     }
 
+    var petTabStillImageName: String? {
+        switch petType {
+        case .seal: nil
+        case .cat: "pet_cat_large_0"
+        }
+    }
+
     // MARK: - Pet Level (monthly JSONL tokens, resets on the 1st)
 
     /// Level 1–5 based on this month's token usage

--- a/ClaudePet/PopoverView.swift
+++ b/ClaudePet/PopoverView.swift
@@ -178,14 +178,23 @@ private struct PetTabView: View {
         VStack(spacing: 0) {
             // Pet display area
             VStack(spacing: 6) {
-                AnimatedPetView(
-                    stage: petManager.petLevel,
-                    size: 96,
-                    fps: petManager.animationFPS,
-                    fallbackEmoji: petManager.emoji,
-                    assetPrefix: petManager.petTabAssetPrefix
-                )
-                .padding(.top, 16)
+                if let stillImageName = petManager.petTabStillImageName {
+                    Image(stillImageName)
+                        .interpolation(.none)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 96, height: 96)
+                        .padding(.top, 16)
+                } else {
+                    AnimatedPetView(
+                        stage: petManager.petLevel,
+                        size: 96,
+                        fps: petManager.animationFPS,
+                        fallbackEmoji: petManager.emoji,
+                        assetPrefix: petManager.petTabAssetPrefix
+                    )
+                    .padding(.top, 16)
+                }
 
                 Text(petManager.sessionMood.badge)
                     .font(.system(size: 11, weight: .semibold))


### PR DESCRIPTION
## Summary
- render the cat pet tab artwork as a direct still image instead of relying on animated fallback logic
- avoid showing the fallback cat emoji in the pet tab when cat is selected

## Testing
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData build

Closes #40