### PR TITLE
[codex] Sync settings state with auth and pet selection

### DIFF
--- a/ClaudePet/AuthLoader.swift
+++ b/ClaudePet/AuthLoader.swift
@@ -9,28 +9,61 @@
 import Foundation
 import Security
 
+enum AuthSource {
+    case credentialsFile
+    case keychain
+
+    var displayName: String {
+        switch self {
+        case .credentialsFile: "Credentials File"
+        case .keychain: "Keychain"
+        }
+    }
+}
+
+struct AuthState {
+    let token: String?
+    let source: AuthSource?
+
+    static let missing = AuthState(token: nil, source: nil)
+}
+
 struct AuthLoader {
+    static func loadAuthState() -> AuthState {
+        if let data = loadCredentialsData(),
+           let token = token(fromCredentialsData: data) {
+            return AuthState(token: token, source: .credentialsFile)
+        }
+
+        if let data = loadKeychainData(),
+           let token = token(fromKeychainPayload: data) {
+            return AuthState(token: token, source: .keychain)
+        }
+
+        return .missing
+    }
+
     static func loadOAuthToken() -> String? {
-        if let token = loadFromCredentialsFile() { return token }
-        return loadFromKeychain()
+        loadAuthState().token
     }
 
     /// Returns the source of the current token, or nil if not found.
     static func authSource() -> String? {
-        if loadFromCredentialsFile() != nil { return "Credentials File" }
-        if loadFromKeychain() != nil { return "Keychain" }
-        return nil
+        loadAuthState().source?.displayName
     }
 
     // MARK: - Credentials File
 
-    private static func loadFromCredentialsFile() -> String? {
+    private static func loadCredentialsData() -> Data? {
         let url = FileManager.default
             .homeDirectoryForCurrentUser
             .appendingPathComponent(".claude/.credentials.json")
 
-        guard let data = try? Data(contentsOf: url),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        return try? Data(contentsOf: url)
+    }
+
+    static func token(fromCredentialsData data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
         else { return nil }
 
         // Typical shape: { "claudeAiOauth": { "accessToken": "..." } }
@@ -44,7 +77,7 @@ struct AuthLoader {
 
     // MARK: - Keychain
 
-    private static func loadFromKeychain() -> String? {
+    private static func loadKeychainData() -> Data? {
         // Keychain service name used by Claude Code (verified 2026-04-02)
         // JSON shape: { "claudeAiOauth": { "accessToken": "sk-ant-oat01-..." } }
         let query: [CFString: Any] = [
@@ -56,8 +89,13 @@ struct AuthLoader {
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         guard status == errSecSuccess,
-              let data = result as? Data,
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let data = result as? Data
+        else { return nil }
+        return data
+    }
+
+    static func token(fromKeychainPayload data: Data) -> String? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let oauth = json["claudeAiOauth"] as? [String: Any],
               let token = oauth["accessToken"] as? String
         else { return nil }

--- a/ClaudePet/PetManager.swift
+++ b/ClaudePet/PetManager.swift
@@ -162,6 +162,7 @@ final class PetManager: ObservableObject {
     @Published var dailyUsage: [Date: Int] = [:]
     @Published var isLoadingJournal = false
     @Published var monthlyTokens: Int = 0
+    @Published private(set) var authState: AuthState = .missing
 
     @Published var petType: PetType {
         didSet { UserDefaults.standard.set(petType.rawValue, forKey: "selectedPetType") }
@@ -292,6 +293,14 @@ final class PetManager: ObservableObject {
         return "최근 5시간 세션 사용량은 \(percent)%예요."
     }
 
+    var authSourceDisplayName: String {
+        authState.source?.displayName ?? "없음"
+    }
+
+    var isAuthenticated: Bool {
+        authState.token != nil
+    }
+
     /// Animation fps: 4 (idle) → 15 (max session). RunCat-style speed.
     var animationFPS: Double {
         let p = fiveHour?.percent ?? 0
@@ -318,11 +327,16 @@ final class PetManager: ObservableObject {
         notificationsEnabled = UserDefaults.standard.bool(forKey: "notificationsEnabled")
         notificationThreshold = UserDefaults.standard.object(forKey: "notificationThreshold") as? Double ?? 0.8
         isInitialized = true
+        refreshAuthStatus()
         startPolling()
         loadJournal()
     }
 
     deinit { pollTask?.cancel() }
+
+    func refreshAuthStatus() {
+        authState = AuthLoader.loadAuthState()
+    }
 
     func loadJournal() {
         isLoadingJournal = true
@@ -372,7 +386,10 @@ final class PetManager: ObservableObject {
         isFetching = true
         defer { isFetching = false }
 
-        guard let token = AuthLoader.loadOAuthToken() else {
+        let currentAuthState = AuthLoader.loadAuthState()
+        authState = currentAuthState
+
+        guard let token = currentAuthState.token else {
             errorMessage = "No OAuth token.\nRun `claude login` in Terminal."
             isLoading = false
             return

--- a/ClaudePet/SettingsView.swift
+++ b/ClaudePet/SettingsView.swift
@@ -14,10 +14,6 @@ struct SettingsView: View {
         ("Off", 0), ("1분", 60), ("2분", 120), ("5분", 300), ("10분", 600)
     ]
 
-    // Auth state evaluated once per view render (cheap)
-    private var authSource: String? { AuthLoader.authSource() }
-    private var isConnected: Bool { authSource != nil }
-
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             // Header
@@ -52,6 +48,9 @@ struct SettingsView: View {
             }
             .padding(14)
         }
+        .onAppear {
+            petManager.refreshAuthStatus()
+        }
     }
 
     // MARK: - Auth Section
@@ -66,9 +65,9 @@ struct SettingsView: View {
             HStack {
                 HStack(spacing: 6) {
                     Circle()
-                        .fill(isConnected ? Color.green : Color.red)
+                        .fill(petManager.isAuthenticated ? Color.green : Color.red)
                         .frame(width: 7, height: 7)
-                    Text(isConnected ? "연결됨" : "연결 안 됨")
+                    Text(petManager.isAuthenticated ? "연결됨" : "연결 안 됨")
                         .font(.caption)
                 }
                 .padding(.horizontal, 8)
@@ -77,12 +76,12 @@ struct SettingsView: View {
 
                 Spacer()
 
-                Text(authSource ?? "없음")
+                Text(petManager.authSourceDisplayName)
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
 
-            if !isConnected {
+            if !petManager.isAuthenticated {
                 Text("터미널에서 `claude login`을 실행하세요.")
                     .font(.caption2)
                     .foregroundColor(.orange)
@@ -116,10 +115,14 @@ struct SettingsView: View {
         let mode = petManager.menuBarDisplayMode
         HStack(spacing: 4) {
             if mode == .imageOnly || mode == .both {
-                Image("pet_stage1_0")
-                    .interpolation(.none)
-                    .resizable()
-                    .frame(width: 22, height: 22)
+                AnimatedPetView(
+                    stage: petManager.petLevel,
+                    size: 22,
+                    fps: max(petManager.animationFPS, 4),
+                    fallbackEmoji: petManager.emoji,
+                    assetPrefix: petManager.menuBarAssetPrefix,
+                    useTemplateRendering: true
+                )
             }
             if mode == .usageOnly || mode == .both {
                 Text(petManager.fiveHour.map { "\(Int($0.utilization))%" } ?? "0%")


### PR DESCRIPTION
## Summary
- cache the current auth source/state and surface it through PetManager
- make Settings reuse the app state instead of re-reading auth on every render
- make the Settings menu bar preview match the currently selected pet

## Why
The Settings screen could drift from the actual app state by repeatedly querying auth sources during rendering and by always previewing the default pet asset.

Closes #46

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData-46 build`
