### PR TITLE
[codex] Load Claude journal usage in a single scan

### DIFF
--- a/ClaudePet/JournalLoader.swift
+++ b/ClaudePet/JournalLoader.swift
@@ -20,83 +20,66 @@
 
 import Foundation
 
+struct JournalSnapshot {
+    let dailyUsage: [Date: Int]
+    let monthlyTokens: Int
+
+    static let empty = JournalSnapshot(dailyUsage: [:], monthlyTokens: 0)
+}
+
 struct JournalLoader {
 
     /// Returns { startOfDay → totalTokens } for the last `days` calendar days.
-    static func load(days: Int = 35) -> [Date: Int] {
+    static func load(days: Int = 35, now: Date = Date(), baseURL: URL? = nil) -> [Date: Int] {
+        loadSnapshot(days: days, now: now, baseURL: baseURL).dailyUsage
+    }
+
+    /// Returns both the recent daily usage map and the current-month total in one filesystem scan.
+    static func loadSnapshot(days: Int = 35, now: Date = Date(), baseURL: URL? = nil) -> JournalSnapshot {
         let cal = Calendar.current
-        let today = cal.startOfDay(for: Date())
+        let today = cal.startOfDay(for: now)
         guard let cutoff = cal.date(byAdding: .day, value: -(days - 1), to: today) else {
-            return [:]
+            return .empty
+        }
+        guard let monthStart = startOfCurrentMonth(for: now, calendar: cal) else {
+            return .empty
         }
 
-        let base = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude/projects")
+        let base = baseURL ?? defaultProjectsURL()
 
         guard let enumerator = FileManager.default.enumerator(
             at: base,
             includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
             options: [.skipsHiddenFiles]
-        ) else { return [:] }
+        ) else { return .empty }
 
-        var result: [Date: Int] = [:]
+        var dailyUsage: [Date: Int] = [:]
+        var monthlyTokens = 0
+        let earliestRelevantDate = min(cutoff, monthStart)
 
         for case let url as URL in enumerator {
             guard url.pathExtension == "jsonl" else { continue }
 
-            // Skip files not touched in the window (cheap pre-filter)
+            // Skip files not touched in either window (cheap pre-filter)
             if let mod = try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate,
-               mod < cutoff { continue }
+               mod < earliestRelevantDate { continue }
 
-            parseFile(url, cutoff: cutoff, calendar: cal, into: &result)
+            parseFile(
+                url,
+                cutoff: cutoff,
+                monthStart: monthStart,
+                calendar: cal,
+                into: &dailyUsage,
+                monthlyTotal: &monthlyTokens
+            )
         }
 
-        return result
+        return JournalSnapshot(dailyUsage: dailyUsage, monthlyTokens: monthlyTokens)
     }
 
     /// Returns total tokens for the current calendar month (resets on the 1st).
-    static func currentMonthTotal() -> Int {
-        let cal = Calendar.current
-        let now = Date()
-        var comps = cal.dateComponents([.year, .month], from: now)
-        comps.day = 1
-        comps.hour = 0; comps.minute = 0; comps.second = 0
-        guard let monthStart = cal.date(from: comps) else { return 0 }
-
-        let base = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude/projects")
-
-        guard let enumerator = FileManager.default.enumerator(
-            at: base,
-            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
-            options: [.skipsHiddenFiles]
-        ) else { return 0 }
-
-        var total = 0
-        for case let url as URL in enumerator {
-            guard url.pathExtension == "jsonl" else { continue }
-            // Pre-filter: skip files not modified this month
-            if let mod = try? url.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate,
-               mod < monthStart { continue }
-
-            guard let content = try? String(contentsOf: url, encoding: .utf8) else { continue }
-            for line in content.split(separator: "\n", omittingEmptySubsequences: true) {
-                guard let data = String(line).data(using: .utf8),
-                      let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                      json["type"] as? String == "assistant",
-                      let tsStr = json["timestamp"] as? String,
-                      let date = parseDate(tsStr),
-                      date >= monthStart,
-                      let message = json["message"] as? [String: Any],
-                      let usage = message["usage"] as? [String: Any]
-                else { continue }
-                total += (usage["input_tokens"]                as? Int ?? 0)
-                       + (usage["output_tokens"]               as? Int ?? 0)
-                       + (usage["cache_creation_input_tokens"] as? Int ?? 0)
-                       + (usage["cache_read_input_tokens"]     as? Int ?? 0)
-            }
-        }
-        return total
+    static func currentMonthTotal(now: Date = Date(), baseURL: URL? = nil) -> Int {
+        loadSnapshot(now: now, baseURL: baseURL).monthlyTokens
     }
 
     // MARK: - File parsing
@@ -104,31 +87,61 @@ struct JournalLoader {
     private static func parseFile(
         _ url: URL,
         cutoff: Date,
+        monthStart: Date,
         calendar cal: Calendar,
-        into result: inout [Date: Int]
+        into result: inout [Date: Int],
+        monthlyTotal: inout Int
     ) {
         guard let content = try? String(contentsOf: url, encoding: .utf8) else { return }
 
         for line in content.split(separator: "\n", omittingEmptySubsequences: true) {
-            guard let data = String(line).data(using: .utf8),
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                  json["type"] as? String == "assistant",
-                  let tsStr = json["timestamp"] as? String,
-                  let date = parseDate(tsStr),
-                  date >= cutoff,
-                  let message = json["message"] as? [String: Any],
-                  let usage = message["usage"] as? [String: Any]
-            else { continue }
+            guard let record = record(from: String(line)) else { continue }
 
-            let tokens = (usage["input_tokens"]                as? Int ?? 0)
-                       + (usage["output_tokens"]               as? Int ?? 0)
-                       + (usage["cache_creation_input_tokens"] as? Int ?? 0)
-                       + (usage["cache_read_input_tokens"]     as? Int ?? 0)
+            if record.date >= cutoff {
+                let day = cal.startOfDay(for: record.date)
+                result[day, default: 0] += record.tokens
+            }
 
-            guard tokens > 0 else { continue }
-            let day = cal.startOfDay(for: date)
-            result[day, default: 0] += tokens
+            if record.date >= monthStart {
+                monthlyTotal += record.tokens
+            }
         }
+    }
+
+    private static func defaultProjectsURL() -> URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".claude/projects")
+    }
+
+    private static func startOfCurrentMonth(for now: Date, calendar cal: Calendar) -> Date? {
+        var comps = cal.dateComponents([.year, .month], from: now)
+        comps.day = 1
+        comps.hour = 0
+        comps.minute = 0
+        comps.second = 0
+        return cal.date(from: comps)
+    }
+
+    static func record(from line: String) -> (date: Date, tokens: Int)? {
+        guard let data = line.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              json["type"] as? String == "assistant",
+              let tsStr = json["timestamp"] as? String,
+              let date = parseDate(tsStr),
+              let message = json["message"] as? [String: Any],
+              let usage = message["usage"] as? [String: Any]
+        else { return nil }
+
+        let tokens = tokenCount(from: usage)
+        guard tokens > 0 else { return nil }
+        return (date, tokens)
+    }
+
+    static func tokenCount(from usage: [String: Any]) -> Int {
+        (usage["input_tokens"]                as? Int ?? 0)
+        + (usage["output_tokens"]               as? Int ?? 0)
+        + (usage["cache_creation_input_tokens"] as? Int ?? 0)
+        + (usage["cache_read_input_tokens"]     as? Int ?? 0)
     }
 
     // MARK: - Date parsing

--- a/ClaudePet/PetManager.swift
+++ b/ClaudePet/PetManager.swift
@@ -341,12 +341,11 @@ final class PetManager: ObservableObject {
     func loadJournal() {
         isLoadingJournal = true
         Task {
-            // Run both heavy file scans concurrently off the main actor
-            async let usageTask   = Task.detached(priority: .utility) { JournalLoader.load() }.value
-            async let monthlyTask = Task.detached(priority: .utility) { JournalLoader.currentMonthTotal() }.value
-            let (usage, monthly) = await (usageTask, monthlyTask)
-            dailyUsage    = usage
-            monthlyTokens = monthly
+            let snapshot = await Task.detached(priority: .utility) {
+                JournalLoader.loadSnapshot()
+            }.value
+            dailyUsage = snapshot.dailyUsage
+            monthlyTokens = snapshot.monthlyTokens
             isLoadingJournal = false
         }
     }

--- a/test_journal_loader.swift
+++ b/test_journal_loader.swift
@@ -1,0 +1,124 @@
+#!/usr/bin/env swift
+// test_journal_loader.swift — JournalLoader 로직 검증
+// 실행:
+// DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift -Xcc -fmodules-cache-path=/tmp/claudepet-module-cache ClaudePet/JournalLoader.swift test_journal_loader.swift
+
+import Foundation
+
+var passed = 0
+var failed = 0
+
+func test(_ name: String, _ block: () throws -> Bool) {
+    do {
+        if try block() {
+            print("  ✅ \(name)")
+            passed += 1
+        } else {
+            print("  ❌ \(name) — assertion failed")
+            failed += 1
+        }
+    } catch {
+        print("  ❌ \(name) — threw: \(error)")
+        failed += 1
+    }
+}
+
+func makeUsageLine(
+    type: String = "assistant",
+    timestamp: String,
+    input: Int = 0,
+    output: Int = 0,
+    cacheCreate: Int = 0,
+    cacheRead: Int = 0
+) -> String {
+    """
+    {"type":"\(type)","timestamp":"\(timestamp)","message":{"usage":{"input_tokens":\(input),"output_tokens":\(output),"cache_creation_input_tokens":\(cacheCreate),"cache_read_input_tokens":\(cacheRead)}}}
+    """
+}
+
+print("\n=== 1. JournalLoader helpers ===")
+
+test("tokenCount sums all token fields") {
+    let usage: [String: Any] = [
+        "input_tokens": 10,
+        "output_tokens": 20,
+        "cache_creation_input_tokens": 5,
+        "cache_read_input_tokens": 3
+    ]
+    return JournalLoader.tokenCount(from: usage) == 38
+}
+
+test("record parses assistant usage line") {
+    let line = makeUsageLine(timestamp: "2026-04-06T00:00:00Z", input: 12, output: 8, cacheRead: 2)
+    guard let record = JournalLoader.record(from: line) else { return false }
+    let expectedDate = ISO8601DateFormatter().date(from: "2026-04-06T00:00:00Z")
+    return record.tokens == 22 && record.date == expectedDate
+}
+
+test("record ignores non-assistant and zero-token lines") {
+    let userLine = makeUsageLine(type: "user", timestamp: "2026-04-06T00:00:00Z", input: 1)
+    let zeroLine = makeUsageLine(timestamp: "2026-04-06T00:00:00Z")
+    return JournalLoader.record(from: userLine) == nil
+        && JournalLoader.record(from: zeroLine) == nil
+}
+
+print("\n=== 2. Journal snapshot ===")
+
+let tempRoot = FileManager.default.temporaryDirectory
+    .appendingPathComponent("ClaudePetJournalTests-\(UUID().uuidString)", isDirectory: true)
+try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+let nestedDir = tempRoot.appendingPathComponent("nested", isDirectory: true)
+try FileManager.default.createDirectory(at: nestedDir, withIntermediateDirectories: true)
+
+let fileOne = tempRoot.appendingPathComponent("session-one.jsonl")
+let fileTwo = nestedDir.appendingPathComponent("session-two.jsonl")
+
+let fileOneLines = [
+    makeUsageLine(timestamp: "2026-04-06T09:00:00Z", input: 10, output: 5),
+    makeUsageLine(timestamp: "2026-04-01T09:00:00Z", input: 20),
+    makeUsageLine(timestamp: "2026-03-05T09:00:00Z", output: 7),
+    makeUsageLine(type: "user", timestamp: "2026-04-06T10:00:00Z", input: 999)
+].joined(separator: "\n")
+
+let fileTwoLines = [
+    makeUsageLine(timestamp: "2026-02-28T09:00:00Z", input: 100),
+    makeUsageLine(timestamp: "2026-04-06T11:00:00Z", cacheCreate: 4, cacheRead: 1)
+].joined(separator: "\n")
+
+try fileOneLines.write(to: fileOne, atomically: true, encoding: .utf8)
+try fileTwoLines.write(to: fileTwo, atomically: true, encoding: .utf8)
+
+test("loadSnapshot returns daily usage and monthly total from one scan") {
+    let now = ISO8601DateFormatter().date(from: "2026-04-06T12:00:00Z")!
+    let snapshot = JournalLoader.loadSnapshot(days: 35, now: now, baseURL: tempRoot)
+    let cal = Calendar.current
+
+    let april6 = cal.startOfDay(for: ISO8601DateFormatter().date(from: "2026-04-06T09:00:00Z")!)
+    let april1 = cal.startOfDay(for: ISO8601DateFormatter().date(from: "2026-04-01T09:00:00Z")!)
+    let march5 = cal.startOfDay(for: ISO8601DateFormatter().date(from: "2026-03-05T09:00:00Z")!)
+
+    return snapshot.dailyUsage[april6] == 20
+        && snapshot.dailyUsage[april1] == 20
+        && snapshot.dailyUsage[march5] == 7
+        && snapshot.monthlyTokens == 40
+}
+
+test("load and currentMonthTotal wrappers stay aligned with snapshot") {
+    let now = ISO8601DateFormatter().date(from: "2026-04-06T12:00:00Z")!
+    let dailyUsage = JournalLoader.load(days: 35, now: now, baseURL: tempRoot)
+    let monthlyTotal = JournalLoader.currentMonthTotal(now: now, baseURL: tempRoot)
+    let april6 = Calendar.current.startOfDay(for: ISO8601DateFormatter().date(from: "2026-04-06T09:00:00Z")!)
+
+    return dailyUsage[april6] == 20 && monthlyTotal == 40
+}
+
+print("\n─────────────────────")
+print("결과: \(passed) passed, \(failed) failed")
+if failed == 0 {
+    print("🎉 All tests passed")
+} else {
+    print("⚠️  \(failed) test(s) failed")
+}
+print("")


### PR DESCRIPTION
## Summary
- compute recent daily usage and the current month total in one filesystem scan
- update PetManager to consume a single journal snapshot instead of launching two scans
- add a journal-focused test script for parser and aggregation coverage

## Why
The app was doing redundant filesystem work by traversing the Claude journal directory twice during startup.

Closes #45

## Testing
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData-45 build`
- `cp test_journal_loader.swift /tmp/main.swift && mkdir -p /tmp/claudepet-module-cache && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swiftc -Xcc -fmodules-cache-path=/tmp/claudepet-module-cache ClaudePet/JournalLoader.swift /tmp/main.swift -o /tmp/test_journal_loader && /tmp/test_journal_loader`
