### PR TITLE
[codex] allow manual refresh to bypass throttling

### DIFF
--- a/ClaudePet/PetManager.swift
+++ b/ClaudePet/PetManager.swift
@@ -368,18 +368,20 @@ final class PetManager: ObservableObject {
     }
 
     func refresh() {
-        Task { await fetchUsage() }
+        Task { await fetchUsage(force: true) }
     }
 
     // MARK: - Fetch
 
-    private func fetchUsage() async {
+    private func fetchUsage(force: Bool = false) async {
         guard !isFetching else { return }   // prevent concurrent fetches
 
         // Enforce minimum interval — never hammer the API faster than once per 60s
-        let elapsed = Date().timeIntervalSince(lastFetchTime)
-        if elapsed < minFetchInterval {
-            try? await Task.sleep(for: .seconds(minFetchInterval - elapsed))
+        if !force {
+            let elapsed = Date().timeIntervalSince(lastFetchTime)
+            if elapsed < minFetchInterval {
+                try? await Task.sleep(for: .seconds(minFetchInterval - elapsed))
+            }
         }
 
         isFetching = true


### PR DESCRIPTION
## Summary
- let the manual refresh action force an immediate usage fetch
- keep the existing minimum fetch interval for automatic polling
- preserve the existing concurrency guard so repeated clicks still do not overlap

## Why
The refresh button could still wait behind the automatic 60-second throttle, which made manual refresh feel broken even when the user explicitly asked for a new fetch.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData-44 build`

Closes #44
