### PR TITLE
[codex] simplify popover routing and animation tasks

### DIFF
--- a/ClaudePet/AnimatedPetView.swift
+++ b/ClaudePet/AnimatedPetView.swift
@@ -53,44 +53,43 @@ struct AnimatedPetView: View {
     var body: some View {
         if let prefix = resolvedPrefix {
             let count = frameCount(for: prefix)
-            let frameImage = Image("\(prefix)_\(frameIndex)")
-                .renderingMode(useTemplateRendering ? .template : .original)
-                .interpolation(.none)
-                .resizable()
-                .frame(width: size, height: size)
-
-            if useTemplateRendering {
-                frameImage
-                    .foregroundStyle(.primary)
-                    .task(id: "\(prefix)-\(fps)-\(count)") {
-                        guard count > 0 else {
-                            frameIndex = 0
-                            return
-                        }
-                        frameIndex = 0
-                        while !Task.isCancelled {
-                            try? await Task.sleep(for: .seconds(1.0 / fps))
-                            frameIndex = (frameIndex + 1) % count
-                        }
-                    }
-            } else {
-                frameImage
-                    .task(id: "\(prefix)-\(fps)-\(count)") {
-                        guard count > 0 else {
-                            frameIndex = 0
-                            return
-                        }
-                        frameIndex = 0
-                        while !Task.isCancelled {
-                            try? await Task.sleep(for: .seconds(1.0 / fps))
-                            frameIndex = (frameIndex + 1) % count
-                        }
-                    }
+            Group {
+                if useTemplateRendering {
+                    frameImage(prefix: prefix)
+                        .foregroundStyle(.primary)
+                } else {
+                    frameImage(prefix: prefix)
+                }
+            }
+            .task(id: "\(prefix)-\(fps)-\(count)") {
+                await runAnimation(frameCount: count)
             }
         } else {
             Text(fallbackEmoji)
                 .font(.system(size: size * 0.75))
                 .frame(width: size, height: size)
+        }
+    }
+
+    private func frameImage(prefix: String) -> some View {
+        Image("\(prefix)_\(frameIndex)")
+            .renderingMode(useTemplateRendering ? .template : .original)
+            .interpolation(.none)
+            .resizable()
+            .frame(width: size, height: size)
+    }
+
+    @MainActor
+    private func runAnimation(frameCount: Int) async {
+        guard frameCount > 1 else {
+            frameIndex = 0
+            return
+        }
+
+        frameIndex = 0
+        while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(1.0 / fps))
+            frameIndex = (frameIndex + 1) % frameCount
         }
     }
 }

--- a/ClaudePet/PopoverView.swift
+++ b/ClaudePet/PopoverView.swift
@@ -9,23 +9,23 @@ import SwiftUI
 // MARK: - Tab
 
 private enum Tab { case usage, analytics, pet }
+private enum Route { case tabs, characterPicker, settings }
 
 // MARK: - Root
 
 struct PopoverView: View {
     @ObservedObject var petManager: PetManager
     @State private var tab: Tab = .usage
-    @State private var showCharacterPicker = false
-    @State private var showSettings = false
+    @State private var route: Route = .tabs
 
     var body: some View {
         Group {
-            if showCharacterPicker {
+            if route == .characterPicker {
                 CharacterPickerView(petManager: petManager) {
-                    showCharacterPicker = false
+                    route = .tabs
                 }
-            } else if showSettings {
-                SettingsView(petManager: petManager) { showSettings = false }
+            } else if route == .settings {
+                SettingsView(petManager: petManager) { route = .tabs }
             } else {
                 VStack(spacing: 0) {
                     tabBar
@@ -40,7 +40,7 @@ struct PopoverView: View {
                         .padding(14)
                     } else {
                         PetTabView(petManager: petManager) {
-                            showCharacterPicker = true
+                            route = .characterPicker
                         }
                     }
                 }
@@ -55,7 +55,7 @@ struct PopoverView: View {
             tabButton("활동",   tab: .analytics,  icon: "square.grid.3x3.fill")
             tabButton("펫",     tab: .pet,        icon: "pawprint.fill")
             Spacer()
-            Button { showSettings = true } label: {
+            Button { route = .settings } label: {
                 Image(systemName: "gearshape")
                     .font(.system(size: 13))
                     .foregroundColor(.secondary)


### PR DESCRIPTION
## Summary
- replace paired popover booleans with a single route enum
- route the settings and character picker screens through one source of truth
- extract the shared sprite frame rendering and animation loop helpers in `AnimatedPetView`

## Why
The popover navigation state was starting to grow into multiple boolean combinations, and the animation loop logic was duplicated across two branches with the same behavior.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData-43 build`

Closes #43
