### PR TITLE
[codex] protect local files and refresh decoder tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+.DS_Store
+
+# Xcode and Swift build outputs
+DerivedData/
+build/
+.build/
+*.xcuserstate
+*.xccheckout
+*.moved-aside
+
+# Per-user Xcode workspace data
+*.xcodeproj/project.xcworkspace/xcuserdata/
+*.xcodeproj/xcuserdata/
+*.xcworkspace/xcuserdata/
+
+# Local environment and secret material
+.env
+.env.*
+*.pem
+*.p12
+*.cer
+*.mobileprovision
+Secrets*.plist
+LocalSecrets*.plist

--- a/test_usage.swift
+++ b/test_usage.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct UsageQuota: Decodable {
     let utilization: Double
-    let resetsAt: Date
+    let resetsAt: Date?
     var percent: Double { min(utilization / 100.0, 1.0) }
     enum CodingKeys: String, CodingKey {
         case utilization
@@ -130,6 +130,15 @@ test("fractional seconds 날짜 파싱") {
     """
     let r = try decode(Data(json.utf8))
     return r.fiveHour != nil
+}
+
+test("resets_at null 허용") {
+    let json = """
+    {"five_hour":{"utilization":12.0,"resets_at":null},
+     "seven_day":null,"seven_day_sonnet":null,"seven_day_opus":null}
+    """
+    let r = try decode(Data(json.utf8))
+    return r.fiveHour?.utilization == 12.0 && r.fiveHour?.resetsAt == nil
 }
 
 test("모든 필드 null") {


### PR DESCRIPTION
## Summary
- add a repository `.gitignore` that blocks common Xcode user data, build outputs, and local secret material
- update `test_usage.swift` so `resets_at` can decode as `null`
- add a regression case that exercises the optional reset date path

## Why
This keeps local machine data and sensitive files out of GitHub by default, and it aligns the decoder test script with the app's current response model.

## Validation
- `mkdir -p /tmp/claudepet-module-cache && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift -Xcc -fmodules-cache-path=/tmp/claudepet-module-cache test_usage.swift` (`9 passed, 2 failed`)
- the remaining 2 failures are the existing environment-dependent Keychain checks for a live local Claude credential

Closes #42
