### PR TITLE
[codex] add clearer refresh feedback

### DIFF
--- a/ClaudePet/PetManager.swift
+++ b/ClaudePet/PetManager.swift
@@ -158,6 +158,7 @@ final class PetManager: ObservableObject {
     @Published var sevenDaySonnet: UsageQuota?
     @Published var sevenDayOpus: UsageQuota?
     @Published var isLoading = false
+    @Published private(set) var lastUsageRefreshAt: Date?
     @Published var errorMessage: String?
     @Published var dailyUsage: [Date: Int] = [:]
     @Published var isLoadingJournal = false
@@ -424,6 +425,7 @@ final class PetManager: ObservableObject {
                 }
                 let usage = try Self.decode(data)
                 applyUsage(usage)
+                lastUsageRefreshAt = Date()
                 rateLimitBackoff = 60   // reset backoff on success
             case 401:
                 errorMessage = "Token expired.\nRun `claude login` again."

--- a/ClaudePet/PopoverView.swift
+++ b/ClaudePet/PopoverView.swift
@@ -11,6 +11,15 @@ import SwiftUI
 private enum Tab { case usage, analytics, pet }
 private enum Route { case tabs, characterPicker, settings }
 
+private struct PressableCapsuleButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.96 : 1.0)
+            .opacity(configuration.isPressed ? 0.88 : 1.0)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+}
+
 // MARK: - Root
 
 struct PopoverView: View {
@@ -125,30 +134,65 @@ private struct MainView: View {
             Divider()
 
             // Bottom bar: refresh (left) + quit (right)
-            HStack {
-                Button { petManager.refresh() } label: {
-                    Image(systemName: "arrow.clockwise")
-                        .rotationEffect(petManager.isLoading ? .degrees(360) : .zero)
-                        .animation(
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Button { petManager.refresh() } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "arrow.clockwise")
+                                .rotationEffect(petManager.isLoading ? .degrees(360) : .zero)
+                                .animation(
+                                    petManager.isLoading
+                                        ? .linear(duration: 1).repeatForever(autoreverses: false)
+                                        : .default,
+                                    value: petManager.isLoading
+                                )
+                                .font(.system(size: 12, weight: .semibold))
+
+                            Text(petManager.isLoading ? "새로고침 중" : "새로고침")
+                                .font(.system(size: 11, weight: .semibold))
+                        }
+                        .foregroundColor(petManager.isLoading ? .white : .primary)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(
                             petManager.isLoading
-                                ? .linear(duration: 1).repeatForever(autoreverses: false)
-                                : .default,
-                            value: petManager.isLoading
+                                ? Color.accentColor
+                                : Color.primary.opacity(0.08),
+                            in: Capsule()
                         )
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
-                }
-                .buttonStyle(.plain)
-                .disabled(petManager.isLoading)
+                    }
+                    .buttonStyle(PressableCapsuleButtonStyle())
+                    .disabled(petManager.isLoading)
 
-                Spacer()
+                    Spacer()
 
-                Button { NSApplication.shared.terminate(nil) } label: {
-                    Image(systemName: "power")
-                        .font(.system(size: 13))
-                        .foregroundColor(.secondary)
+                    Button { NSApplication.shared.terminate(nil) } label: {
+                        Image(systemName: "power")
+                            .font(.system(size: 13))
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(.plain)
                 }
-                .buttonStyle(.plain)
+                
+                HStack(spacing: 6) {
+                    if petManager.isLoading {
+                        ProgressView()
+                            .controlSize(.small)
+                            .scaleEffect(0.65)
+                        Text("최신 사용량을 확인하고 있어요")
+                    } else if let lastRefreshAt = petManager.lastUsageRefreshAt {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                        Text("마지막 업데이트")
+                        Text(lastRefreshAt, style: .relative)
+                    } else {
+                        Image(systemName: "hand.tap")
+                        .foregroundColor(.secondary)
+                        Text("버튼을 눌러 최신 사용량을 가져오세요")
+                    }
+                }
+                .font(.caption2)
+                .foregroundColor(.secondary)
             }
         }
         .padding(14)


### PR DESCRIPTION
## Summary
- replace the icon-only refresh control with a labeled capsule button that shows a pressed state
- surface in-flight loading text so manual refresh feels responsive immediately
- record the last successful usage refresh time and show a short relative status after refresh completes

## Why
The previous refresh control only spun while loading, so it could feel like taps were ignored when the request finished quickly or if the button state changed subtly.

## Validation
- `/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData-refresh-feedback-pr build`
