### PR TITLE
fix: remove pet name badge from pet tab

### DIFF
--- a/ClaudePet/PopoverView.swift
+++ b/ClaudePet/PopoverView.swift
@@ -290,14 +290,6 @@ private struct PetTabView: View {
                     .padding(.top, 16)
                 }
 
-                // 펫 이름 뱃지
-                Text(petManager.petType.displayName)
-                    .font(.system(size: 11, weight: .medium))
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 4)
-                    .background(Color.accentColor.opacity(0.1), in: Capsule())
-                    .foregroundColor(.accentColor.opacity(0.8))
-
                 // 무드 뱃지 + 대사
                 Text(petManager.sessionMood.badge)
                     .font(.system(size: 11, weight: .medium))


### PR DESCRIPTION
Closes #56

## Summary
- 펫 탭 상단 이름 뱃지(accentColor 캡슐) 제거
- 무드 뱃지 + 대사만 남겨 레이아웃 간결화

🤖 Generated with [Claude Code](https://claude.com/claude-code)