### PR TITLE
chore: remove dead code and fix force unwrap

### DIFF
--- a/ClaudePet/ClaudePetApp.swift
+++ b/ClaudePet/ClaudePetApp.swift
@@ -10,7 +10,6 @@ import SwiftUI
 @main
 struct ClaudePetApp: App {
     @StateObject private var petManager = PetManager()
-    @State private var popoverIsShown = false
 
     var body: some Scene {
         MenuBarExtra {

--- a/ClaudePet/PetManager.swift
+++ b/ClaudePet/PetManager.swift
@@ -250,8 +250,6 @@ final class PetManager: ObservableObject {
         }
     }
 
-    var petTabStillImageName: String? { nil }
-
     // MARK: - Pet Level (monthly JSONL tokens, resets on the 1st)
 
     /// Level 1–5 based on this month's token usage
@@ -291,13 +289,9 @@ final class PetManager: ObservableObject {
 
     /// Yesterday's token count from JSONL
     var yesterdayTokens: Int {
-        let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: Calendar.current.startOfDay(for: Date()))!
+        let today = Calendar.current.startOfDay(for: Date())
+        guard let yesterday = Calendar.current.date(byAdding: .day, value: -1, to: today) else { return 0 }
         return dailyUsage[yesterday] ?? 0
-    }
-
-    /// Status message based on current session utilization
-    var petStatusMessage: String {
-        sessionMood.headline
     }
 
     var sessionMood: SessionMood {

--- a/ClaudePet/PopoverView.swift
+++ b/ClaudePet/PopoverView.swift
@@ -272,23 +272,14 @@ private struct PetTabView: View {
         VStack(spacing: 0) {
             // Pet display area
             VStack(spacing: 8) {
-                if let stillImageName = petManager.petTabStillImageName {
-                    Image(stillImageName)
-                        .interpolation(.none)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 96, height: 96)
-                        .padding(.top, 16)
-                } else {
-                    AnimatedPetView(
-                        stage: petManager.petLevel,
-                        size: 96,
-                        fps: petManager.animationFPS,
-                        fallbackEmoji: petManager.emoji,
-                        assetPrefix: petManager.petTabAssetPrefix
-                    )
-                    .padding(.top, 16)
-                }
+                AnimatedPetView(
+                    stage: petManager.petLevel,
+                    size: 96,
+                    fps: petManager.animationFPS,
+                    fallbackEmoji: petManager.emoji,
+                    assetPrefix: petManager.petTabAssetPrefix
+                )
+                .padding(.top, 16)
 
                 // 무드 뱃지 + 대사
                 Text(petManager.sessionMood.badge)


### PR DESCRIPTION
Closes #58

## Changes
- `ClaudePetApp`: remove `@State private var popoverIsShown` (never read)
- `PetManager`: remove `petTabStillImageName` (always returned nil) and `petStatusMessage` (never called)
- `PopoverView`: remove dead `if let stillImageName` branch that was always skipped
- `PetManager.yesterdayTokens`: replace `!` force-unwrap with `guard let` + safe `return 0` fallback

## Security
No sensitive files in repo — confirmed via .gitignore and git-tracked file review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)