### PR TITLE
[codex] Extract usage API responsibilities out of PetManager

### DIFF
--- a/ClaudePet.xcodeproj/project.pbxproj
+++ b/ClaudePet.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		BB000009000000000000001A /* AnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000009000000000000001A /* AnalyticsView.swift */; };
 		BB00000A000000000000001A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000A000000000000001A /* SettingsView.swift */; };
 		BB00000B000000000000001A /* AnimatedPetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000B000000000000001A /* AnimatedPetView.swift */; };
+		BB00000C000000000000001A /* UsageAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000C000000000000001A /* UsageAPIClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +33,7 @@
 		AA000009000000000000001A /* AnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsView.swift; sourceTree = "<group>"; };
 		AA00000A000000000000001A /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		AA00000B000000000000001A /* AnimatedPetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedPetView.swift; sourceTree = "<group>"; };
+		AA00000C000000000000001A /* UsageAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageAPIClient.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +61,7 @@
 				AA000009000000000000001A /* AnalyticsView.swift */,
 				AA00000A000000000000001A /* SettingsView.swift */,
 				AA00000B000000000000001A /* AnimatedPetView.swift */,
+				AA00000C000000000000001A /* UsageAPIClient.swift */,
 			);
 			path = ClaudePet;
 			sourceTree = "<group>";
@@ -157,6 +160,7 @@
 				BB000009000000000000001A /* AnalyticsView.swift in Sources */,
 				BB00000A000000000000001A /* SettingsView.swift in Sources */,
 				BB00000B000000000000001A /* AnimatedPetView.swift in Sources */,
+				BB00000C000000000000001A /* UsageAPIClient.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ClaudePet/PetManager.swift
+++ b/ClaudePet/PetManager.swift
@@ -117,58 +117,6 @@ enum SessionMood {
     }
 }
 
-// MARK: - API Response Models
-
-struct UsageQuota: Decodable {
-    /// 0–100 percent
-    let utilization: Double
-    /// nil when API omits or nulls the field (e.g. immediately after a reset)
-    let resetsAt: Date?
-
-    /// 0.0–1.0 for progress bars / stage logic
-    var percent: Double { min(utilization / 100.0, 1.0) }
-
-    enum CodingKeys: String, CodingKey {
-        case utilization
-        case resetsAt = "resets_at"
-    }
-}
-
-struct ExtraUsage: Decodable {
-    let isEnabled: Bool
-    /// Spending limit in dollars (e.g. 2000 = $2,000)
-    let monthlyLimit: Double
-    /// Amount spent so far this month in dollars
-    let usedCredits: Double
-    /// 0–100 percent; nil when nothing has been spent yet
-    let utilization: Double?
-
-    var percent: Double { min((utilization ?? 0) / 100.0, 1.0) }
-
-    enum CodingKeys: String, CodingKey {
-        case isEnabled    = "is_enabled"
-        case monthlyLimit = "monthly_limit"
-        case usedCredits  = "used_credits"
-        case utilization
-    }
-}
-
-struct OAuthUsageResponse: Decodable {
-    let fiveHour: UsageQuota?
-    let sevenDay: UsageQuota?
-    let sevenDaySonnet: UsageQuota?
-    let sevenDayOpus: UsageQuota?
-    let extraUsage: ExtraUsage?
-
-    enum CodingKeys: String, CodingKey {
-        case fiveHour       = "five_hour"
-        case sevenDay       = "seven_day"
-        case sevenDaySonnet = "seven_day_sonnet"
-        case sevenDayOpus   = "seven_day_opus"
-        case extraUsage     = "extra_usage"
-    }
-}
-
 // MARK: - PetManager
 
 @MainActor
@@ -332,8 +280,7 @@ final class PetManager: ObservableObject {
     private var rateLimitBackoff: Double = 60   // seconds; doubles on each 429, resets on success
     private var lastFetchTime: Date = .distantPast  // minimum 60s between requests
     private var isInitialized = false           // blocks didSet observers during init
-    private let endpoint        = URL(string: "https://api.anthropic.com/api/oauth/usage")!
-    private let accountEndpoint = URL(string: "https://api.anthropic.com/api/account")!
+    private let usageClient = UsageAPIClient()
     private let minFetchInterval: Double = 60   // never request more than once per minute
 
     init() {
@@ -362,24 +309,12 @@ final class PetManager: ObservableObject {
     func fetchPlanInfo() {
         guard let token = authState.token else { return }
         Task {
-            var request = URLRequest(url: accountEndpoint)
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
-            guard let (data, resp) = try? await URLSession.shared.data(for: request),
-                  (resp as? HTTPURLResponse)?.statusCode == 200,
-                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-            else {
+            do {
+                if let rawPlan = try await usageClient.fetchPlanName(token: token) {
+                    planName = formatPlanName(rawPlan)
+                }
+            } catch {
                 print("[ClaudePet] account endpoint unavailable or failed")
-                return
-            }
-            print("[ClaudePet] /api/account: \(json)")
-            // Parse known plan fields — update keys once confirmed via log
-            let raw = json["subscription_plan"] as? String
-                   ?? json["plan"] as? String
-                   ?? json["plan_name"] as? String
-                   ?? json["tier"] as? String
-            if let raw {
-                planName = formatPlanName(raw)
             }
         }
     }
@@ -456,54 +391,37 @@ final class PetManager: ObservableObject {
         errorMessage = nil
         lastFetchTime = Date()
 
-        var request = URLRequest(url: endpoint)
-        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
-
-        var responseData: Data?
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            responseData = data
-
-            guard let http = response as? HTTPURLResponse else {
-                throw URLError(.badServerResponse)
+            let usage = try await usageClient.fetchUsage(token: token)
+            applyUsage(usage)
+            lastUsageRefreshAt = Date()
+            rateLimitBackoff = 60
+        } catch UsageAPIClientError.payloadMessage(let message) {
+            if fiveHour == nil { errorMessage = message }
+        } catch UsageAPIClientError.unauthorized {
+            errorMessage = "Token expired.\nRun `claude login` again."
+        } catch UsageAPIClientError.rateLimited {
+            rateLimitBackoff = min(rateLimitBackoff * 2, 1800)
+            lastFetchTime = Date()
+            if fiveHour == nil {
+                errorMessage = "Rate limited by API.\nWill retry automatically."
             }
-
-            switch http.statusCode {
-            case 200:
-                // Guard against error body disguised as 200 (e.g. rate_limit_error)
-                if let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                   let apiError = raw["error"] as? [String: Any],
-                   let msg = apiError["message"] as? String {
-                    if fiveHour == nil { errorMessage = msg }
-                    break
-                }
-                let usage = try Self.decode(data)
-                applyUsage(usage)
-                lastUsageRefreshAt = Date()
-                rateLimitBackoff = 60   // reset backoff on success
-            case 401:
-                errorMessage = "Token expired.\nRun `claude login` again."
-            case 429:
-                // Exponential backoff: 60s → 120s → 240s … up to 30min
-                rateLimitBackoff = min(rateLimitBackoff * 2, 1800)
-                lastFetchTime = Date()  // delay next fetch by backoff duration
-                if fiveHour == nil {
-                    errorMessage = "Rate limited by API.\nWill retry automatically."
-                }
-            default:
-                errorMessage = "API error \(http.statusCode)"
-            }
-        } catch let error as DecodingError {
-            // JSON shape mismatch — log raw body and surface clearly
+        } catch UsageAPIClientError.api(let statusCode) {
+            errorMessage = "API error \(statusCode)"
+        } catch UsageAPIClientError.decoding(let error, let rawBody) {
             errorMessage = "Unexpected API response.\nCheck app update."
             print("[ClaudePet] Decode error: \(error)")
-            if let data = responseData,
-               let raw = try? JSONSerialization.jsonObject(with: data) {
-                print("[ClaudePet] Raw body: \(raw)")
+            if let rawBody {
+                print("[ClaudePet] Raw body: \(rawBody)")
             }
+        } catch UsageAPIClientError.invalidResponse {
+            errorMessage = "Unexpected API response.\nCheck app update."
         } catch {
-            errorMessage = error.localizedDescription
+            if let urlError = error as? URLError, urlError.code == .userAuthenticationRequired {
+                errorMessage = "Token expired.\nRun `claude login` again."
+            } else {
+                errorMessage = error.localizedDescription
+            }
         }
 
         isLoading = false
@@ -538,32 +456,5 @@ final class PetManager: ObservableObject {
     private func requestNotificationPermission() {
         UNUserNotificationCenter.current()
             .requestAuthorization(options: [.alert, .sound]) { _, _ in }
-    }
-
-    // MARK: - Decoding
-
-    private nonisolated(unsafe) static let isoFrac: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        return f
-    }()
-    private nonisolated(unsafe) static let isoPlain: ISO8601DateFormatter = {
-        let f = ISO8601DateFormatter()
-        f.formatOptions = [.withInternetDateTime]
-        return f
-    }()
-
-    private static func decode(_ data: Data) throws -> OAuthUsageResponse {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .custom { dec in
-            let str = try dec.singleValueContainer().decode(String.self)
-            if let d = isoFrac.date(from: str)  { return d }
-            if let d = isoPlain.date(from: str) { return d }
-            throw DecodingError.dataCorruptedError(
-                in: try dec.singleValueContainer(),
-                debugDescription: "Cannot parse date: \(str)"
-            )
-        }
-        return try decoder.decode(OAuthUsageResponse.self, from: data)
     }
 }

--- a/ClaudePet/UsageAPIClient.swift
+++ b/ClaudePet/UsageAPIClient.swift
@@ -1,0 +1,157 @@
+//
+//  UsageAPIClient.swift
+//  ClaudePet
+//
+//  Isolates the OAuth usage/account API request and decoding behavior so
+//  PetManager can focus on state transitions and view-facing logic.
+//
+
+import Foundation
+
+struct UsageQuota: Decodable {
+    /// 0–100 percent
+    let utilization: Double
+    /// nil when API omits or nulls the field (e.g. immediately after a reset)
+    let resetsAt: Date?
+
+    /// 0.0–1.0 for progress bars / stage logic
+    var percent: Double { min(utilization / 100.0, 1.0) }
+
+    enum CodingKeys: String, CodingKey {
+        case utilization
+        case resetsAt = "resets_at"
+    }
+}
+
+struct ExtraUsage: Decodable {
+    let isEnabled: Bool
+    /// Spending limit in dollars (e.g. 2000 = $2,000)
+    let monthlyLimit: Double
+    /// Amount spent so far this month in dollars
+    let usedCredits: Double
+    /// 0–100 percent; nil when nothing has been spent yet
+    let utilization: Double?
+
+    var percent: Double { min((utilization ?? 0) / 100.0, 1.0) }
+
+    enum CodingKeys: String, CodingKey {
+        case isEnabled    = "is_enabled"
+        case monthlyLimit = "monthly_limit"
+        case usedCredits  = "used_credits"
+        case utilization
+    }
+}
+
+struct OAuthUsageResponse: Decodable {
+    let fiveHour: UsageQuota?
+    let sevenDay: UsageQuota?
+    let sevenDaySonnet: UsageQuota?
+    let sevenDayOpus: UsageQuota?
+    let extraUsage: ExtraUsage?
+
+    enum CodingKeys: String, CodingKey {
+        case fiveHour       = "five_hour"
+        case sevenDay       = "seven_day"
+        case sevenDaySonnet = "seven_day_sonnet"
+        case sevenDayOpus   = "seven_day_opus"
+        case extraUsage     = "extra_usage"
+    }
+}
+
+enum UsageAPIClientError: Error {
+    case invalidResponse
+    case payloadMessage(String)
+    case unauthorized
+    case rateLimited
+    case api(statusCode: Int)
+    case decoding(DecodingError, rawBody: String?)
+}
+
+struct UsageAPIClient {
+    private let endpoint = URL(string: "https://api.anthropic.com/api/oauth/usage")!
+    private let accountEndpoint = URL(string: "https://api.anthropic.com/api/account")!
+
+    func fetchUsage(token: String) async throws -> OAuthUsageResponse {
+        let request = authorizedRequest(url: endpoint, token: token)
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw UsageAPIClientError.invalidResponse
+        }
+
+        switch http.statusCode {
+        case 200:
+            if let raw = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let apiError = raw["error"] as? [String: Any],
+               let message = apiError["message"] as? String {
+                throw UsageAPIClientError.payloadMessage(message)
+            }
+
+            do {
+                return try Self.decodeUsage(data)
+            } catch let error as DecodingError {
+                throw UsageAPIClientError.decoding(error, rawBody: String(data: data, encoding: .utf8))
+            }
+        case 401:
+            throw UsageAPIClientError.unauthorized
+        case 429:
+            throw UsageAPIClientError.rateLimited
+        default:
+            throw UsageAPIClientError.api(statusCode: http.statusCode)
+        }
+    }
+
+    func fetchPlanName(token: String) async throws -> String? {
+        let request = authorizedRequest(url: accountEndpoint, token: token)
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw UsageAPIClientError.invalidResponse
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw UsageAPIClientError.invalidResponse
+        }
+
+        return json["subscription_plan"] as? String
+            ?? json["plan"] as? String
+            ?? json["plan_name"] as? String
+            ?? json["tier"] as? String
+    }
+
+    private func authorizedRequest(url: URL, token: String) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("oauth-2025-04-20", forHTTPHeaderField: "anthropic-beta")
+        return request
+    }
+
+    private nonisolated(unsafe) static let isoFrac: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private nonisolated(unsafe) static let isoPlain: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    static func decodeUsage(_ data: Data) throws -> OAuthUsageResponse {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let rawValue = try container.decode(String.self)
+            if let date = isoFrac.date(from: rawValue) { return date }
+            if let date = isoPlain.date(from: rawValue) { return date }
+
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Cannot parse date: \(rawValue)"
+            )
+        }
+
+        return try decoder.decode(OAuthUsageResponse.self, from: data)
+    }
+}


### PR DESCRIPTION
## Summary
- move OAuth usage/account request and decoding logic into a dedicated `UsageAPIClient`
- keep `PetManager` focused on auth refresh, polling, backoff, and state updates
- wire the new Swift file into the Xcode project so the app builds cleanly

## Why
`PetManager` was carrying network request construction, status handling, and date decoding alongside UI-facing state. Separating the API client makes the next UI/UX changes smaller and lowers the chance of mixing transport concerns into view state logic.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData-60 build`