### PR TITLE
[codex] Add regression coverage for sprite and usage view state helpers

### DIFF
--- a/ClaudePet.xcodeproj/project.pbxproj
+++ b/ClaudePet.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		BB00000B000000000000001A /* AnimatedPetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000B000000000000001A /* AnimatedPetView.swift */; };
 		BB00000C000000000000001A /* UsageAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000C000000000000001A /* UsageAPIClient.swift */; };
 		BB00000D000000000000001A /* SpriteFrameCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000D000000000000001A /* SpriteFrameCatalog.swift */; };
+		BB00000E000000000000001A /* UsageViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000E000000000000001A /* UsageViewState.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		AA00000B000000000000001A /* AnimatedPetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimatedPetView.swift; sourceTree = "<group>"; };
 		AA00000C000000000000001A /* UsageAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageAPIClient.swift; sourceTree = "<group>"; };
 		AA00000D000000000000001A /* SpriteFrameCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteFrameCatalog.swift; sourceTree = "<group>"; };
+		AA00000E000000000000001A /* UsageViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageViewState.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +67,7 @@
 				AA00000B000000000000001A /* AnimatedPetView.swift */,
 				AA00000C000000000000001A /* UsageAPIClient.swift */,
 				AA00000D000000000000001A /* SpriteFrameCatalog.swift */,
+				AA00000E000000000000001A /* UsageViewState.swift */,
 			);
 			path = ClaudePet;
 			sourceTree = "<group>";
@@ -165,6 +168,7 @@
 				BB00000B000000000000001A /* AnimatedPetView.swift in Sources */,
 				BB00000C000000000000001A /* UsageAPIClient.swift in Sources */,
 				BB00000D000000000000001A /* SpriteFrameCatalog.swift in Sources */,
+				BB00000E000000000000001A /* UsageViewState.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ClaudePet/UsageViewState.swift
+++ b/ClaudePet/UsageViewState.swift
@@ -1,0 +1,46 @@
+//
+//  UsageViewState.swift
+//  ClaudePet
+//
+//  Pure helpers for deciding whether usage content stays visible and whether a
+//  loading or error banner should be shown above it.
+//
+
+import Foundation
+
+enum UsageBannerStyle: Equatable {
+    case info
+    case error
+}
+
+struct UsageBannerState: Equatable {
+    let style: UsageBannerStyle
+    let message: String
+}
+
+struct UsageViewState: Equatable {
+    let showsUsageContent: Bool
+    let banner: UsageBannerState?
+
+    static func resolve(
+        hasUsageData: Bool,
+        isLoading: Bool,
+        errorMessage: String?
+    ) -> UsageViewState {
+        if let errorMessage, !errorMessage.isEmpty {
+            return UsageViewState(
+                showsUsageContent: hasUsageData,
+                banner: UsageBannerState(style: .error, message: errorMessage)
+            )
+        }
+
+        if isLoading && !hasUsageData {
+            return UsageViewState(
+                showsUsageContent: false,
+                banner: UsageBannerState(style: .info, message: "Loading")
+            )
+        }
+
+        return UsageViewState(showsUsageContent: hasUsageData, banner: nil)
+    }
+}

--- a/test_view_state.swift
+++ b/test_view_state.swift
@@ -1,0 +1,76 @@
+#!/usr/bin/env swift
+// test_view_state.swift — SpriteFrameCatalog / UsageViewState regression checks
+// 실행:
+// DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift \
+//   -Xcc -fmodules-cache-path=/tmp/claudepet-module-cache \
+//   ClaudePet/SpriteFrameCatalog.swift ClaudePet/UsageViewState.swift test_view_state.swift
+
+import Foundation
+
+var passed = 0
+var failed = 0
+
+func test(_ name: String, _ block: () throws -> Bool) {
+    do {
+        if try block() {
+            print("  ✅ \(name)")
+            passed += 1
+        } else {
+            print("  ❌ \(name) — assertion failed")
+            failed += 1
+        }
+    } catch {
+        print("  ❌ \(name) — threw: \(error)")
+        failed += 1
+    }
+}
+
+print("\n=== 1. SpriteFrameCatalog ===")
+
+test("prefers numbered frames when both numbered and single-frame assets exist") {
+    let available: Set<String> = ["pet_cat_menu", "pet_cat_menu_0", "pet_cat_menu_1"]
+    let frames = SpriteFrameCatalog.frames(for: "pet_cat_menu") { available.contains($0) }
+    return frames == ["pet_cat_menu_0", "pet_cat_menu_1"]
+}
+
+test("falls back to single-frame asset when no numbered frames exist") {
+    let available: Set<String> = ["pet_preview_cat"]
+    let frames = SpriteFrameCatalog.frames(for: "pet_preview_cat") { available.contains($0) }
+    return frames == ["pet_preview_cat"]
+}
+
+test("returns first available prefix in search order") {
+    let available: Set<String> = ["pet_stage2_0", "pet_stage2_1"]
+    let frames = SpriteFrameCatalog.firstAvailableFrames(
+        prefixes: ["pet_stage3", "pet_stage2", "pet_stage1"]
+    ) { available.contains($0) }
+    return frames == ["pet_stage2_0", "pet_stage2_1"]
+}
+
+print("\n=== 2. UsageViewState ===")
+
+test("keeps usage content visible when stale data exists alongside an error") {
+    let state = UsageViewState.resolve(hasUsageData: true, isLoading: false, errorMessage: "Rate limited")
+    return state.showsUsageContent
+        && state.banner == UsageBannerState(style: .error, message: "Rate limited")
+}
+
+test("shows loading banner before first successful fetch") {
+    let state = UsageViewState.resolve(hasUsageData: false, isLoading: true, errorMessage: nil)
+    return !state.showsUsageContent
+        && state.banner == UsageBannerState(style: .info, message: "Loading")
+}
+
+test("hides banner when data is available and no status message exists") {
+    let state = UsageViewState.resolve(hasUsageData: true, isLoading: false, errorMessage: nil)
+    return state.showsUsageContent && state.banner == nil
+}
+
+print("\n─────────────────────")
+print("결과: \(passed) passed, \(failed) failed")
+if failed == 0 {
+    print("🎉 All tests passed")
+} else {
+    print("⚠️  \(failed) test(s) failed")
+}
+print("")


### PR DESCRIPTION
## Summary
- add a pure `UsageViewState` helper for deciding when usage content stays visible and when a banner is needed
- add regression coverage for `SpriteFrameCatalog` and the new usage view-state rules
- wire the helper into the Xcode project so later UI work can consume it directly

## Why
The next UX changes depend on two behavior contracts staying stable: sprite animations should resolve frames predictably, and refresh errors should not automatically wipe out the last successful usage content. This PR locks both behaviors down with lightweight coverage.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData-61 build`
- combined script execution for `test_view_state.swift`: `6 passed, 0 failed`