### PR TITLE
[codex] Keep usage data visible during refresh failures

### DIFF
--- a/ClaudePet/PetManager.swift
+++ b/ClaudePet/PetManager.swift
@@ -260,6 +260,22 @@ final class PetManager: ObservableObject {
         return "최근 5시간 세션 사용량은 \(percent)%예요."
     }
 
+    var hasUsageData: Bool {
+        fiveHour != nil
+            || sevenDay != nil
+            || sevenDaySonnet != nil
+            || sevenDayOpus != nil
+            || extraUsage != nil
+    }
+
+    var usageViewState: UsageViewState {
+        UsageViewState.resolve(
+            hasUsageData: hasUsageData,
+            isLoading: isLoading,
+            errorMessage: errorMessage
+        )
+    }
+
     var authSourceDisplayName: String {
         authState.source?.displayName ?? "없음"
     }

--- a/ClaudePet/PopoverView.swift
+++ b/ClaudePet/PopoverView.swift
@@ -192,6 +192,10 @@ struct PopoverView: View {
 private struct MainView: View {
     @ObservedObject var petManager: PetManager
 
+    private var viewState: UsageViewState {
+        petManager.usageViewState
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             // Plan badge
@@ -207,12 +211,11 @@ private struct MainView: View {
                 }
             }
 
-            if let error = petManager.errorMessage {
-                Text(error)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.leading)
-            } else {
+            if let banner = viewState.banner {
+                usageBanner(banner)
+            }
+
+            if viewState.showsUsageContent {
                 usageRow("Session (5h)",  quota: petManager.fiveHour,      color: .blue)
                 usageRow("Weekly (7d)",   quota: petManager.sevenDay,       color: .green)
                 usageRow("Sonnet Weekly", quota: petManager.sevenDaySonnet, color: .orange)
@@ -222,9 +225,43 @@ private struct MainView: View {
                     Divider()
                     extraUsageRow(extra)
                 }
+            } else {
+                firstLoadPlaceholder
             }
         }
         .padding(14)
+    }
+
+    private var firstLoadPlaceholder: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Checking...")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 6)
+    }
+
+    private func usageBanner(_ banner: UsageBannerState) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: banner.style == .error ? "exclamationmark.triangle.fill" : "arrow.clockwise.circle.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(banner.style == .error ? .orange : .accentColor)
+
+            Text(banner.message)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.leading)
+
+            Spacer(minLength: 0)
+        }
+        .padding(10)
+        .background(
+            (banner.style == .error ? Color.orange : Color.accentColor)
+                .opacity(0.10),
+            in: RoundedRectangle(cornerRadius: 8)
+        )
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary
- expose a pure `usageViewState` from `PetManager`
- keep the last successful usage cards visible when refreshes fail
- render loading and error states as a banner instead of replacing the entire usage area

## Why
A transient network or auth failure should not wipe out the most recent successful usage data. This keeps the popover stable and turns refresh failures into non-blocking status UI.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData-64 build`
- combined `test_view_state.swift` run: `6 passed, 0 failed`