### PR TITLE
[codex] Add persisted usage snapshot cache

### DIFF
--- a/ClaudePet.xcodeproj/project.pbxproj
+++ b/ClaudePet.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		BB00000C000000000000001A /* UsageAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000C000000000000001A /* UsageAPIClient.swift */; };
 		BB00000D000000000000001A /* SpriteFrameCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000D000000000000001A /* SpriteFrameCatalog.swift */; };
 		BB00000E000000000000001A /* UsageViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000E000000000000001A /* UsageViewState.swift */; };
+		BB00000F000000000000001A /* UsageSnapshotCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000F000000000000001A /* UsageSnapshotCache.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +39,7 @@
 		AA00000C000000000000001A /* UsageAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageAPIClient.swift; sourceTree = "<group>"; };
 		AA00000D000000000000001A /* SpriteFrameCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteFrameCatalog.swift; sourceTree = "<group>"; };
 		AA00000E000000000000001A /* UsageViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageViewState.swift; sourceTree = "<group>"; };
+		AA00000F000000000000001A /* UsageSnapshotCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageSnapshotCache.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,6 +70,7 @@
 				AA00000C000000000000001A /* UsageAPIClient.swift */,
 				AA00000D000000000000001A /* SpriteFrameCatalog.swift */,
 				AA00000E000000000000001A /* UsageViewState.swift */,
+				AA00000F000000000000001A /* UsageSnapshotCache.swift */,
 			);
 			path = ClaudePet;
 			sourceTree = "<group>";
@@ -169,6 +172,7 @@
 				BB00000C000000000000001A /* UsageAPIClient.swift in Sources */,
 				BB00000D000000000000001A /* SpriteFrameCatalog.swift in Sources */,
 				BB00000E000000000000001A /* UsageViewState.swift in Sources */,
+				BB00000F000000000000001A /* UsageSnapshotCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ClaudePet/UsageAPIClient.swift
+++ b/ClaudePet/UsageAPIClient.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-struct UsageQuota: Decodable {
+struct UsageQuota: Codable {
     /// 0–100 percent
     let utilization: Double
     /// nil when API omits or nulls the field (e.g. immediately after a reset)
@@ -23,7 +23,7 @@ struct UsageQuota: Decodable {
     }
 }
 
-struct ExtraUsage: Decodable {
+struct ExtraUsage: Codable {
     let isEnabled: Bool
     /// Spending limit in dollars (e.g. 2000 = $2,000)
     let monthlyLimit: Double
@@ -42,7 +42,7 @@ struct ExtraUsage: Decodable {
     }
 }
 
-struct OAuthUsageResponse: Decodable {
+struct OAuthUsageResponse: Codable {
     let fiveHour: UsageQuota?
     let sevenDay: UsageQuota?
     let sevenDaySonnet: UsageQuota?

--- a/ClaudePet/UsageSnapshotCache.swift
+++ b/ClaudePet/UsageSnapshotCache.swift
@@ -1,0 +1,98 @@
+//
+//  UsageSnapshotCache.swift
+//  ClaudePet
+//
+//  Stores only the last successful usage snapshot so the UI can show
+//  last-known-good data when the usage API is temporarily unavailable.
+//
+
+import Foundation
+
+struct CachedUsageSnapshot: Codable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let fetchedAt: Date
+    let usage: OAuthUsageResponse
+    let planName: String?
+
+    init(
+        fetchedAt: Date,
+        usage: OAuthUsageResponse,
+        planName: String?,
+        schemaVersion: Int = Self.currentSchemaVersion
+    ) {
+        self.schemaVersion = schemaVersion
+        self.fetchedAt = fetchedAt
+        self.usage = usage
+        self.planName = planName
+    }
+
+    var isCurrentSchema: Bool {
+        schemaVersion == Self.currentSchemaVersion
+    }
+}
+
+struct UsageSnapshotCache {
+    private let fileURL: URL
+    private let fileManager: FileManager
+
+    init(fileURL: URL = Self.defaultFileURL(), fileManager: FileManager = .default) {
+        self.fileURL = fileURL
+        self.fileManager = fileManager
+    }
+
+    func load() -> CachedUsageSnapshot? {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return nil }
+
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let snapshot = try Self.decoder.decode(CachedUsageSnapshot.self, from: data)
+            return snapshot.isCurrentSchema ? snapshot : nil
+        } catch {
+            print("[ClaudePet] Failed to load usage cache: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    func save(_ snapshot: CachedUsageSnapshot) throws {
+        let directory = fileURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let data = try Self.encoder.encode(snapshot)
+        try data.write(to: fileURL, options: [.atomic])
+    }
+
+    func remove() {
+        guard fileManager.fileExists(atPath: fileURL.path) else { return }
+        do {
+            try fileManager.removeItem(at: fileURL)
+        } catch {
+            print("[ClaudePet] Failed to remove usage cache: \(error.localizedDescription)")
+        }
+    }
+
+    static func defaultFileURL(fileManager: FileManager = .default) -> URL {
+        if let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            return appSupport
+                .appendingPathComponent("ClaudePet", isDirectory: true)
+                .appendingPathComponent("usage-cache.json")
+        }
+
+        return fileManager.temporaryDirectory
+            .appendingPathComponent("ClaudePet", isDirectory: true)
+            .appendingPathComponent("usage-cache.json")
+    }
+
+    private nonisolated(unsafe) static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return encoder
+    }()
+
+    private nonisolated(unsafe) static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+}


### PR DESCRIPTION
## Summary
- Add a `UsageSnapshotCache` JSON store for the last successful usage snapshot.
- Make usage response models `Codable` so snapshots can be persisted without raw auth payloads.
- Register the new cache source file with the Xcode target.

## Why
Rate-limit and transient API fallback need a safe last-known-good usage snapshot before the app starts wiring cached data into the UI.

Closes #77

## Validation
- `/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData-cache-store build`
- `git diff --check`