### PR TITLE
[codex] Adjust analytics popover size

### DIFF
--- a/ClaudePet/PopoverView.swift
+++ b/ClaudePet/PopoverView.swift
@@ -58,14 +58,14 @@ struct PopoverView: View {
                         }
                         .frame(maxWidth: .infinity)
                     }
-                    .frame(height: 360)
+                    .frame(height: 420)
 
                     Divider()
                     bottomBar
                 }
             }
         }
-        .frame(width: 280)
+        .frame(width: 320)
     }
 
     // MARK: - Tab Bar


### PR DESCRIPTION
## Summary
- Increase the menu popover width from 280 to 320 points
- Increase the tab content height from 360 to 420 points

## Why
The Analytics tab now includes a 7-day trend chart above the 35-day activity history. The larger popover gives the chart and history more breathing room without changing feature behavior.

## Validation
- `xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -sdk macosx -derivedDataPath /tmp/ClaudePetDerivedData-analytics-size-pr build`
- `git diff --check`

Closes #84