### PR TITLE
[codex] Hotfix extra usage null decoding for 1.0.2

### DIFF
--- a/ClaudePet.xcodeproj/project.pbxproj
+++ b/ClaudePet.xcodeproj/project.pbxproj
@@ -316,7 +316,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hoon.ClaudePet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -342,7 +342,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.hoon.ClaudePet;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/ClaudePet/PopoverView.swift
+++ b/ClaudePet/PopoverView.swift
@@ -306,11 +306,11 @@ private struct MainView: View {
                 Text("Extra Usage")
                     .font(.caption).fontWeight(.medium)
                 Spacer()
-                Text(String(format: "%.0f%%", extra.percent * 100))
+                Text(extra.utilizationText)
                     .font(.caption2).foregroundColor(.secondary)
             }
             ProgressView(value: extra.percent).tint(.secondary)
-            Text(String(format: "$%.2f / $%.2f this month", extra.usedCredits, extra.monthlyLimit))
+            Text(extra.spendingSummaryText)
                 .font(.caption2).foregroundColor(.secondary.opacity(0.7))
         }
     }

--- a/ClaudePet/UsageAPIClient.swift
+++ b/ClaudePet/UsageAPIClient.swift
@@ -26,19 +26,39 @@ struct UsageQuota: Codable {
 struct ExtraUsage: Codable {
     let isEnabled: Bool
     /// Spending limit in dollars (e.g. 2000 = $2,000)
-    let monthlyLimit: Double
+    let monthlyLimit: Double?
     /// Amount spent so far this month in dollars
-    let usedCredits: Double
+    let usedCredits: Double?
     /// 0–100 percent; nil when nothing has been spent yet
     let utilization: Double?
 
     var percent: Double { min((utilization ?? 0) / 100.0, 1.0) }
+
+    var utilizationText: String {
+        guard let utilization else { return "—" }
+        return String(format: "%.0f%%", utilization)
+    }
+
+    var spendingSummaryText: String {
+        guard let usedCredits, let monthlyLimit else {
+            return "Usage details unavailable"
+        }
+        return String(format: "$%.2f / $%.2f this month", usedCredits, monthlyLimit)
+    }
 
     enum CodingKeys: String, CodingKey {
         case isEnabled    = "is_enabled"
         case monthlyLimit = "monthly_limit"
         case usedCredits  = "used_credits"
         case utilization
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        isEnabled = try container.decodeIfPresent(Bool.self, forKey: .isEnabled) ?? false
+        monthlyLimit = try container.decodeIfPresent(Double.self, forKey: .monthlyLimit)
+        usedCredits = try container.decodeIfPresent(Double.self, forKey: .usedCredits)
+        utilization = try container.decodeIfPresent(Double.self, forKey: .utilization)
     }
 }
 


### PR DESCRIPTION
## Summary
- allow `extra_usage` fields from `/api/oauth/usage` to be `null` without failing the whole decode
- fall back gracefully in the usage UI when extra-usage details are unavailable
- bump the app version to `1.0.2` for a hotfix release

## Root cause
The usage decoder treated `extra_usage.monthly_limit` and `extra_usage.used_credits` as required `Double` values. Some live API responses return those fields as `null` when extra usage is disabled, which caused the app to show `Unexpected API response. Check app update.` instead of rendering usage normally.

## Validation
- `xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -configuration Debug build`
- `xcodebuild -project ClaudePet.xcodeproj -scheme ClaudePet -configuration Release build`
- `./scripts/build-release.sh 1.0.2`
