### PR TITLE
[codex] add english and korean readmes

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,218 @@
+# ClaudePet
+
+Claude Pro/Max 사용량을 macOS 메뉴 막대에서 확인하는 작은 픽셀아트 펫 앱입니다.
+
+ClaudePet은 Mac에 저장된 Claude Code OAuth 로그인을 읽고, Claude 사용량을 주기적으로 확인해서 현재 5시간 세션 상태를 메뉴 막대에 표시합니다. 최근 활동 차트와 펫 레벨 진행도는 로컬 Claude Code 저널 파일을 기반으로 계산합니다.
+
+![macOS](https://img.shields.io/badge/macOS-13%2B-blue)
+![Swift](https://img.shields.io/badge/Swift-5.9%2B-orange)
+![License](https://img.shields.io/badge/license-MIT-green)
+
+언어: [English](README.md) | [한국어](README.ko.md)
+
+## 기능
+
+### 메뉴 막대
+
+- macOS 메뉴 막대에 표시되는 애니메이션 펫 스프라이트
+- 선택적으로 표시되는 5시간 세션 사용률
+- 표시 모드: 아이콘만, 사용률만, 둘 다
+- 현재 세션 상태, 캐시 데이터 상태, 인증 오류를 알려주는 툴팁
+
+### Usage 탭
+
+- Claude 쿼터 행:
+  - Session (5h)
+  - Weekly (7d)
+  - Sonnet weekly
+  - Opus weekly
+- API가 `resets_at`을 제공할 때 표시되는 리셋 카운트다운
+- `/api/account`에서 플랜명이 내려올 때 표시되는 플랜 배지
+- 계정에서 `extra_usage.is_enabled`가 켜져 있을 때 표시되는 Extra Usage 행
+- 인증 누락, 만료된 인증, API 오류, rate limit을 알려주는 배너
+- API를 일시적으로 사용할 수 없을 때 마지막으로 성공한 사용량 캐시 표시
+
+### Stats 탭
+
+- hover 상세 정보를 제공하는 7일 토큰 추이 차트
+- 35일 로컬 활동 히트맵
+- 총 토큰, 활성 일수, 현재 연속 사용일, 활성일 평균, 전주 대비 비교
+- 데이터는 로컬 Claude Code JSONL 저널에서 읽습니다.
+
+### Pet 탭
+
+- 더 크게 표시되는 애니메이션 펫
+- 5시간 사용률 기반 세션 기분 배지:
+  - `0-1%`: 휴식중
+  - `1-20%`: 안정적
+  - `20-40%`: 시동중
+  - `40-60%`: 집중중
+  - `60-100%`: 과열직전
+- 세션 사용률에 따라 4 fps에서 15 fps까지 변하는 애니메이션 속도
+- 이번 달 로컬 Claude Code 토큰 사용량 기반 펫 레벨과 XP 진행도
+- 오늘, 어제, 이번 달 토큰 수
+- 물범과 고양이를 고를 수 있는 캐릭터 선택 화면
+
+### Settings
+
+- 인증 상태와 토큰 출처
+- 자동 새로고침 간격: Off, 1m, 2m, 5m, 10m
+- 50%에서 95%까지 설정 가능한 로컬 알림 기준
+- 메뉴 막대 표시 모드 선택
+
+## 요구사항
+
+- macOS 13 Ventura 이상
+- Claude Pro 또는 Max 계정으로 로그인된 Claude Code
+- 소스에서 빌드할 경우 Xcode 15 이상
+
+ClaudePet은 Claude Code OAuth 사용자를 위한 앱입니다. Anthropic API 키는 사용하지 않습니다.
+
+## 설치
+
+### 릴리스 다운로드
+
+[Releases](https://github.com/Jjiggu/ClaudePet/releases) 페이지에서 최신 DMG를 다운로드하고, 연 뒤 `ClaudePet.app`을 Applications 폴더로 드래그하세요.
+
+### Homebrew
+
+```bash
+brew tap Jjiggu/tap
+brew install --cask Jjiggu/tap/claudepet
+```
+
+### 소스에서 빌드
+
+```bash
+git clone https://github.com/Jjiggu/ClaudePet.git
+cd ClaudePet
+open ClaudePet.xcodeproj
+```
+
+Xcode에서 `ClaudePet` 스킴을 선택하고 `Cmd+R`로 실행하세요.
+
+로컬 릴리스 DMG를 만들려면 다음을 실행합니다.
+
+```bash
+./scripts/build-release.sh
+```
+
+이 스크립트는 Xcode 프로젝트 버전을 기준으로 `dist/ClaudePet-{version}.dmg`를 생성합니다.
+
+## 인증
+
+ClaudePet은 Claude Code가 만든 OAuth 토큰을 읽습니다. 별도 API 키나 설정 화면은 필요하지 않습니다.
+
+먼저 Claude Code를 설치하고 로그인하세요.
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude login
+```
+
+토큰 조회 순서:
+
+1. `~/.claude/.credentials.json`
+2. macOS Keychain 서비스 `Claude Code-credentials`
+
+토큰을 찾지 못하면 ClaudePet이 인증 오류를 표시하고, Settings 화면의 Authentication 상태가 `Not connected`로 표시됩니다.
+
+## 데이터 소스
+
+| 데이터 | 소스 |
+| --- | --- |
+| 5시간, 7일, Sonnet weekly, Opus weekly 쿼터 | `GET https://api.anthropic.com/api/oauth/usage` |
+| Extra Usage | `GET https://api.anthropic.com/api/oauth/usage` |
+| 플랜명 | `GET https://api.anthropic.com/api/account` |
+| 일별 활동, 월간 토큰, 펫 레벨 | `~/.claude/projects/**/*.jsonl` |
+
+사용량과 계정 API 요청은 로컬 Claude Code OAuth 토큰과 `anthropic-beta: oauth-2025-04-20` 헤더를 사용해 Anthropic으로 전송됩니다.
+
+저널 파싱은 로컬에서만 수행됩니다. ClaudePet은 assistant 레코드를 읽고 다음 값을 합산합니다.
+
+- `input_tokens`
+- `output_tokens`
+- `cache_creation_input_tokens`
+- `cache_read_input_tokens`
+
+## 폴링과 캐시
+
+- 기본 자동 새로고침 간격은 5분입니다.
+- 수동 새로고침도 자동 새로고침과 같은 rate limit 보호를 사용합니다.
+- ClaudePet은 사용량 API 요청을 1분보다 자주 보내지 않습니다.
+- HTTP 429 또는 rate limit 응답을 받으면 재시도 backoff가 60초에서 최대 30분까지 2배씩 증가합니다.
+- 마지막으로 성공한 사용량 응답은 `~/Library/Application Support/ClaudePet/usage-cache.json`에 저장됩니다.
+- 새 데이터를 가져올 수 없으면 캐시된 사용량을 주황색 상태 표시와 함께 보여줍니다.
+- 플랜명은 24시간 동안 캐시됩니다.
+
+## 펫 레벨
+
+펫 레벨은 로컬 Claude Code 저널에서 파싱한 이번 달 토큰 사용량을 기준으로 계산합니다. 카운터는 매월 1일 자연스럽게 초기화됩니다.
+
+| 레벨 | 월간 토큰 |
+| --- | ---: |
+| Lv.1 | 0 - 49,999,999 |
+| Lv.2 | 50,000,000 - 199,999,999 |
+| Lv.3 | 200,000,000 - 499,999,999 |
+| Lv.4 | 500,000,000 - 999,999,999 |
+| Lv.5 | 1,000,000,000+ |
+
+## 캐릭터
+
+| 캐릭터 | 표시 이름 | 메뉴 막대 프레임 | Pet 탭 프레임 |
+| --- | --- | ---: | ---: |
+| Seal | 물범 말랑이 | 6 | 6 |
+| Cat | 고양 말랑이 | 2 | 2 |
+
+선택한 캐릭터, 메뉴 막대 표시 모드, 새로고침 간격, 알림 설정, backoff 상태, 캐시된 플랜명, 최신 사용량 캐시는 로컬에 저장됩니다.
+
+## 개인정보와 보안
+
+- ClaudePet은 Claude Code가 로컬에 저장한 동일한 OAuth 로그인을 읽습니다.
+- Anthropic API 키를 요구하거나 저장하지 않습니다.
+- 앱 설정과 마지막으로 성공한 사용량 스냅샷만 로컬에 저장합니다.
+- 로컬 저널 파싱은 사용자의 Mac 안에서만 수행됩니다.
+- 네트워크 요청은 위에 나열한 Anthropic 사용량 및 계정 엔드포인트로 제한됩니다.
+- 앱은 sandbox를 사용하지 않습니다. `~/.claude` 파일과 Claude Code Keychain 항목에 접근해야 하기 때문입니다.
+
+## 문제 해결
+
+### OAuth 토큰 없음
+
+다음을 실행하세요.
+
+```bash
+claude login
+```
+
+그 뒤 ClaudePet Settings를 열고 Authentication이 `Connected`인지 확인하세요.
+
+### Rate Limited
+
+팝오버에 표시되는 다음 재시도 시간까지 기다리세요. 수동 새로고침을 반복해도 cooldown을 우회하지 못하며, upstream rate limit이 더 오래 지속될 수 있습니다.
+
+### Stats가 비어 있음
+
+Stats는 `~/.claude/projects` 아래의 로컬 Claude Code 저널 파일이 필요합니다. Claude Code가 assistant 사용량 레코드를 기록한 뒤 표시됩니다.
+
+### 캐시된 사용량이 오래되어 보임
+
+API를 사용할 수 없을 때 ClaudePet은 마지막으로 성공한 사용량 스냅샷을 계속 보여줍니다. 캐시 모드에서는 팝오버 상태 표시가 주황색으로 바뀝니다.
+
+## 개발 참고
+
+- 앱 진입점: `ClaudePet/ClaudePetApp.swift`
+- 공유 상태와 폴링: `ClaudePet/PetManager.swift`
+- OAuth 사용량/계정 API 클라이언트: `ClaudePet/UsageAPIClient.swift`
+- Claude Code 토큰 로딩: `ClaudePet/AuthLoader.swift`
+- JSONL 저널 파싱: `ClaudePet/JournalLoader.swift`
+- 메뉴 막대 UI: `ClaudePet/MenuBarView.swift`
+- 팝오버 탭과 캐릭터 선택: `ClaudePet/PopoverView.swift`
+- 분석 UI: `ClaudePet/AnalyticsView.swift`
+- 설정 UI: `ClaudePet/SettingsView.swift`
+
+이 프로젝트는 외부 패키지 의존성이 없으며, 현재 XCTest 타깃은 없습니다.
+
+## 라이선스
+
+MIT. [LICENSE](LICENSE)를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,82 @@
-# ClaudePet 🐾
+# ClaudePet
 
-macOS 메뉴바에서 Claude Pro/Max 토큰 사용량을 모니터링하는 앱.
-토큰 사용량에 따라 픽셀아트 말랑이 캐릭터가 반응하는 다마고치 컨셉.
+ClaudePet은 macOS 메뉴바에서 Claude 사용량을 확인하고, 로컬 Claude Code 활동량을 작은 펫 UI로 보여주는 SwiftUI 앱입니다.
 
 ![macOS](https://img.shields.io/badge/macOS-13%2B-blue)
-![Swift](https://img.shields.io/badge/Swift-5.9%2B-orange)
+![SwiftUI](https://img.shields.io/badge/SwiftUI-macOS-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
-## 스크린샷
+## 소개
 
-| 메뉴바 | 사용량 팝오버 | 펫 탭 |
-|--------|-------------|-------|
-| 상태바에 말랑이 + 사용량 % | 세션/주간 사용량 진행바 | 레벨 & 성장 현황 |
+이 앱은 두 가지 데이터를 함께 보여줍니다.
 
-## 기능
+- Claude OAuth usage API 기반의 현재 사용량
+- 로컬 `~/.claude/projects/**/*.jsonl` 기록 기반의 활동 히스토리
 
-- **실시간 사용량 모니터링** — Claude OAuth API로 5시간 세션 / 7일 주간 사용량 표시
-- **말랑이 캐릭터** — 사용량에 따라 애니메이션 속도 변화 (RunCat 스타일)
-- **펫 성장 시스템** — JSONL 히스토리 기반 월간 토큰으로 레벨 1~5 성장
-- **자동 새로고침** — 1분 / 2분 / 5분 / 10분 주기 선택
-- **사용량 알림** — 지정 임계값(50~95%) 도달 시 로컬 알림
-- **메뉴바 표시 옵션** — 아이콘만 / 사용량만 / 둘 다 선택 가능
-- **말랑이 선택** — 노랑 말랑이 / 고양 말랑이 / 용 말랑이
+결과적으로 메뉴바에서는 현재 세션 사용량을 빠르게 확인할 수 있고, 팝오버에서는 최근 활동과 펫 성장 상태까지 한 번에 볼 수 있습니다.
 
-## 캐릭터 단계 (세션 사용량 기준)
+## 현재 구현된 기능
 
-| 단계 | 범위 | 상태 |
-|------|------|------|
-| 🥚 알 | 0~20% | 대기중... |
-| 🐣 부화 | 20~40% | 여유롭네~ |
-| 🐥 병아리 | 40~60% | 열심히 일중! |
-| 🐓 닭 | 60~80% | 바쁘다 바빠... |
-| 🔥 과부하 | 80~100% | 과부하! |
+- **메뉴바 실시간 표시**: 픽셀 펫, 세션 사용량 퍼센트, 또는 둘 다 표시
+- **사용량 팝오버**: `5시간 세션`, `7일 전체`, `7일 Sonnet`, `7일 Opus` 진행률 표시
+- **자동 새로고침**: `Off`, `1분`, `2분`, `5분`, `10분` 선택 가능
+- **수동 새로고침**: 팝오버에서 즉시 재조회
+- **로컬 알림**: 세션 사용량이 지정 임계값 이상일 때 경고 알림
+- **활동 히트맵**: 최근 35일 토큰 활동량 시각화
+- **펫 성장 시스템**: 이번 달 누적 토큰 기준 레벨 1~5 성장
+- **펫 선택**: 노랑 말랑이, 고양 말랑이, 용 말랑이 선택
+- **인증 상태 확인**: credentials 파일 또는 Keychain에서 로그인 상태 감지
+- **API 보호 로직**: 최소 호출 간격, 중복 요청 방지, 429 백오프 처리
 
-## 설치
+## 화면 구성
 
-### 요구사항
+- **Menu Bar**: 펫 애니메이션과 세션 사용량 표시
+- **Usage 탭**: Claude OAuth 사용량과 다음 리셋 시점 표시
+- **Activity 탭**: 최근 35일 히트맵과 누적 토큰 요약
+- **Pet 탭**: 현재 레벨, 상태 메시지, 오늘/이번 달 토큰 확인
+- **Settings 뷰**: 인증 상태, 자동 새로고침, 알림 임계값, 메뉴바 표시 모드 설정
 
-- macOS 13 (Ventura) 이상
+## 동작 방식
+
+### 1. Claude 인증 정보 읽기
+
+ClaudePet은 아래 순서로 OAuth 토큰을 찾습니다.
+
+1. `~/.claude/.credentials.json`
+2. macOS Keychain의 `Claude Code-credentials`
+
+즉, 먼저 `claude login`이 완료되어 있어야 합니다.
+
+### 2. 사용량 데이터 조회
+
+주 데이터 소스:
+
+- `GET https://api.anthropic.com/api/oauth/usage`
+- 헤더: `Authorization: Bearer <token>`
+- 헤더: `anthropic-beta: oauth-2025-04-20`
+
+이 API 응답에서 다음 값을 읽습니다.
+
+- `five_hour`
+- `seven_day`
+- `seven_day_sonnet`
+- `seven_day_opus`
+
+### 3. 로컬 활동 데이터 집계
+
+보조 데이터 소스:
+
+- `~/.claude/projects/**/*.jsonl`
+
+여기서 Claude Code 세션의 `input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`를 합산해 최근 활동과 월간 성장 수치를 계산합니다.
+
+## 요구사항
+
+- macOS 13 이상
 - Xcode 15 이상
-- Claude Pro 또는 Max 구독 + `claude login` 완료
+- Claude Code 로그인 완료
 
-### 빌드
+## 실행 방법
 
 ```bash
 git clone https://github.com/Jjiggu/ClaudePet.git
@@ -49,41 +84,41 @@ cd ClaudePet
 open ClaudePet.xcodeproj
 ```
 
-Xcode에서 `⌘R` 로 실행.
+Xcode에서 `ClaudePet` 스킴으로 실행하면 됩니다.
 
-### 인증 설정
-
-Claude CLI가 설치되어 있어야 함:
+`claude login`이 아직 안 되어 있다면 먼저 아래를 실행하세요.
 
 ```bash
-# Claude CLI 설치
 npm install -g @anthropic-ai/claude-code
-
-# 로그인
 claude login
 ```
 
-로그인 후 `~/.claude/.credentials.json` 또는 macOS Keychain에 토큰이 저장됨. ClaudePet이 자동으로 감지.
-
 ## 기술 스택
 
-- **Swift 5.9+** / **SwiftUI** / **macOS 13+**
-- 외부 의존성 없음 (Zero dependencies)
-- Swift Concurrency (async/await) — GCD 미사용
-- RAM 목표: ~20~30MB (RunCat 수준)
+- SwiftUI
+- Swift Concurrency (`async/await`)
+- macOS MenuBarExtra
+- 외부 의존성 없음
 
-## 데이터 소스
+## 프로젝트 구조
 
-1. **OAuth API** (주): `GET https://api.anthropic.com/api/oauth/usage`
-   - 5시간 세션 / 7일 누적 / 소네트 주간 / 오퍼스 주간 쿼터 반환
-2. **JSONL 파싱** (보조): `~/.claude/projects/**/*.jsonl`
-   - Claude Code 세션의 input/output 토큰 → 일별/월별 사용량 집계
+```text
+ClaudePetApp.swift      앱 진입점, MenuBarExtra 구성
+PetManager.swift        사용량 조회, 상태 관리, 폴링, 알림, 레벨 계산
+AuthLoader.swift        credentials 파일 / Keychain 토큰 로딩
+JournalLoader.swift     Claude Code JSONL 집계
+MenuBarView.swift       메뉴바 상태 표시
+PopoverView.swift       팝오버 루트와 탭 UI
+AnalyticsView.swift     35일 활동 히트맵
+SettingsView.swift      설정 화면
+AnimatedPetView.swift   픽셀 펫 애니메이션
+```
 
-## 레퍼런스
+## 참고
 
-- [Claude God](https://github.com/Lcharvol/Claude-God) (MIT) — OAuth API 연동 방식 참고
-- [TokenEater](https://github.com/AThevon/TokenEater) (MIT) — 경량 아키텍처 참고
-- [RunCat](https://kyome.io/runcat/) — UI/UX 컨셉 참고
+- [Claude God](https://github.com/Lcharvol/Claude-God): OAuth usage API 연동 방식 참고
+- [TokenEater](https://github.com/AThevon/TokenEater): 경량 macOS 유틸리티 구조 참고
+- [RunCat](https://kyome.io/runcat/): 메뉴바 캐릭터 UX 컨셉 참고
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -1,93 +1,87 @@
-# ClaudePet 🦭
+# ClaudePet
 
-A macOS menu bar app that monitors your Claude Pro/Max usage in real time — with an animated pixel-art pet that reacts to how hard you're working.
+macOS menu bar app for monitoring Claude Pro/Max usage with a small animated pixel-art pet.
 
-> Claude Pro/Max 사용량을 실시간으로 모니터링하는 macOS 메뉴바 앱입니다. 세션 사용량에 따라 움직임이 달라지는 픽셀아트 펫 캐릭터와 함께합니다.
+ClaudePet reads the Claude Code OAuth login already stored on your Mac, checks your Claude usage periodically, and shows the current 5-hour session status from the menu bar. Local Claude Code journal files are used for recent activity charts and pet level progress.
 
 ![macOS](https://img.shields.io/badge/macOS-13%2B-blue)
 ![Swift](https://img.shields.io/badge/Swift-5.9%2B-orange)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
----
+Language: [English](README.md) | [한국어](README.ko.md)
 
-## What is ClaudePet? / 소개
+## Features
 
-ClaudePet sits in your menu bar and shows your Claude session quota at a glance. The pet character (Seal or Cat) animates faster as your 5-hour session fills up — 4 fps at idle, 15 fps when you're running hot. It grows in level as your monthly token usage accumulates, like a Tamagotchi for your Claude usage.
+### Menu Bar
 
-> 메뉴바에 상주하며 Claude 5시간 세션 쿼터를 한눈에 확인할 수 있습니다. 펫(물범 또는 고양이)은 세션 사용량에 따라 애니메이션 속도가 달라지고, 월간 토큰 사용량이 쌓이면 레벨이 오릅니다.
+- Animated pet sprite in the macOS menu bar
+- Optional 5-hour session usage percentage
+- Display modes: icon only, usage only, or both
+- Tooltip with current session status, cached-data state, or auth error
 
----
+### Usage Tab
 
-## Features / 기능
+- Claude quota rows for:
+  - Session (5h)
+  - Weekly (7d)
+  - Sonnet weekly
+  - Opus weekly
+- Reset countdowns when the API provides `resets_at`
+- Plan badge when `/api/account` returns a plan name
+- Extra Usage row when the account has `extra_usage.is_enabled`
+- Clear banners for missing auth, expired auth, API errors, and rate limiting
+- Last-known-good usage cache when the API is temporarily unavailable
 
-### Usage Tab / 사용량 탭
-- **4 live quota bars** — 5h session, 7-day weekly, Sonnet weekly, Opus weekly
-- **Extra Usage card** — shows monthly overage when enabled on your plan
-- **Plan name badge** — displays your current Claude plan
-- **Reset countdown** — shows exactly when each quota resets
-- **Error banners** — clear hints when authentication fails or you're rate limited
-- **Cached display** — shows last known usage with an orange indicator when the API is unavailable
+### Stats Tab
 
-> 5시간 세션 / 7일 주간 / 소네트 주간 / 오퍼스 주간 쿼터를 프로그레스 바로 표시합니다. API 오류 시 마지막 캐시 데이터를 주황색 표시와 함께 보여줍니다.
+- 7-day token trend chart with hover details
+- 35-day local activity heatmap
+- Total tokens, active days, current streak, active-day average, and week-over-week comparison
+- Data is read locally from Claude Code JSONL journals
 
-### Stats Tab / 통계 탭
-- **35-day activity heatmap** — GitHub-style grid showing daily token usage
-- **7-day trend chart** — cubic Bézier curve with hover tooltips
-- **Summary cards** — current streak, daily average, week-over-week comparison
-- **Monthly totals** — total tokens and active day count
+### Pet Tab
 
-> 35일 토큰 히트맵, 7일 트렌드 차트, 연속 사용일·일평균·주간 비교 카드를 제공합니다.
+- Larger animated pet display
+- Session mood badge based on 5-hour usage:
+  - `0-1%`: 휴식중
+  - `1-20%`: 안정적
+  - `20-40%`: 시동중
+  - `40-60%`: 집중중
+  - `60-100%`: 과열직전
+- Animation speed scales with session usage from 4 fps to 15 fps
+- Pet level and XP progress based on this month's local Claude Code token usage
+- Today, yesterday, and current-month token counts
+- Character picker for Seal and Cat
 
-### Pet Tab / 펫 탭
-- **Animated pet display** — reacts to your current session activity
-- **Session condition badge** — 5 moods based on your 5h quota usage
-- **XP level bar** — progress toward next level (Lv.1–5)
-- **Today / Yesterday token counts** — from local Claude Code journals
-- **Character selector** — switch between Seal and Cat
+### Settings
 
-> 세션 상태에 따른 펫 애니메이션, 기분 배지, 레벨 진행 바, 오늘/어제 토큰 수를 보여줍니다.
-
-### Menu Bar / 메뉴바
-- Animated pet sprite + optional usage percentage
-- Display modes: icon only / percentage only / both
-
-> 메뉴바에 애니메이션 펫과 사용량 퍼센트를 함께 또는 개별로 표시할 수 있습니다.
-
-### Settings / 설정
-- Auto-refresh interval: Off / 1m / 2m / 5m / 10m
-- Local notifications when session crosses a threshold (50–95%)
+- Authentication status and token source
+- Auto-refresh interval: Off, 1m, 2m, 5m, or 10m
+- Local notification threshold from 50% to 95%
 - Menu bar display mode selector
 
----
+## Requirements
 
-## Requirements / 요구사항
+- macOS 13 Ventura or later
+- Claude Code installed and logged in with a Claude Pro or Max account
+- Xcode 15 or later when building from source
 
-- macOS 13 (Ventura) or later
-- [Claude Code](https://claude.ai/code) installed and authenticated (`claude login`)
-- Claude Pro or Max subscription
+ClaudePet is for Claude Code OAuth users. It does not use Anthropic API keys.
 
-> Xcode는 소스 빌드 시에만 필요합니다. 릴리스 빌드를 다운로드하면 별도 설치 불필요합니다.
+## Installation
 
----
+### Download Release
 
-## Installation / 설치
+Download the latest DMG from the [Releases](https://github.com/Jjiggu/ClaudePet/releases) page, open it, and drag `ClaudePet.app` to Applications.
 
-### Option 1: Download Release (recommended) / 릴리스 다운로드 (권장)
-
-Download the latest `.dmg` from the [Releases](../../releases) page, open it, and drag ClaudePet to your Applications folder.
-
-> [Releases](../../releases) 페이지에서 최신 `.dmg`를 다운로드하여 응용 프로그램 폴더로 드래그하세요.
-
-### Option 2: Homebrew / Homebrew로 설치
+### Homebrew
 
 ```bash
 brew tap Jjiggu/tap
 brew install --cask Jjiggu/tap/claudepet
 ```
 
-> Gatekeeper quarantine 속성이 설치 시 자동으로 제거되므로 별도 우회 작업이 필요하지 않습니다.
-
-### Option 3: Build from Source / 소스 빌드
+### Build From Source
 
 ```bash
 git clone https://github.com/Jjiggu/ClaudePet.git
@@ -95,127 +89,130 @@ cd ClaudePet
 open ClaudePet.xcodeproj
 ```
 
-Press ⌘R in Xcode to build and run.
+Select the `ClaudePet` scheme in Xcode and run it with `Cmd+R`.
 
----
+For a local release DMG:
 
-## Authentication / 인증
-
-ClaudePet reads the OAuth token that Claude Code stores locally — no separate API key needed.
-
-> Claude Code가 로컬에 저장한 OAuth 토큰을 자동으로 읽습니다. 별도 API 키 불필요합니다.
-
-**Step 1**: Install Claude Code
 ```bash
-npm install -g @anthropic-ai/claude-code
+./scripts/build-release.sh
 ```
 
-**Step 2**: Log in
+The script creates `dist/ClaudePet-{version}.dmg` from the Xcode project version.
+
+## Authentication
+
+ClaudePet reads the OAuth token created by Claude Code. No separate API key or setup screen is required.
+
+Install and log in to Claude Code first:
+
+```bash
+npm install -g @anthropic-ai/claude-code
+claude login
+```
+
+Token lookup order:
+
+1. `~/.claude/.credentials.json`
+2. macOS Keychain service `Claude Code-credentials`
+
+If no token is found, ClaudePet shows an authentication error and the Settings view reports `Not connected`.
+
+## Data Sources
+
+| Data | Source |
+| --- | --- |
+| 5-hour, 7-day, Sonnet weekly, Opus weekly quotas | `GET https://api.anthropic.com/api/oauth/usage` |
+| Extra Usage | `GET https://api.anthropic.com/api/oauth/usage` |
+| Plan name | `GET https://api.anthropic.com/api/account` |
+| Daily activity, monthly tokens, pet level | `~/.claude/projects/**/*.jsonl` |
+
+Usage and account API requests are sent to Anthropic with your local Claude Code OAuth token and the `anthropic-beta: oauth-2025-04-20` header.
+
+Journal parsing is local. ClaudePet counts assistant records and sums:
+
+- `input_tokens`
+- `output_tokens`
+- `cache_creation_input_tokens`
+- `cache_read_input_tokens`
+
+## Polling And Caching
+
+- Default auto-refresh interval is 5 minutes.
+- Manual refresh uses the same rate-limit guard as automatic refresh.
+- ClaudePet never sends usage API requests more frequently than once per minute.
+- On HTTP 429 or rate-limit responses, retry backoff doubles from 60 seconds up to 30 minutes.
+- The last successful usage response is saved at `~/Library/Application Support/ClaudePet/usage-cache.json`.
+- Cached usage is shown with an orange status indicator when fresh data cannot be fetched.
+- Plan name is cached for 24 hours.
+
+## Pet Levels
+
+Pet level is based on current-month token usage parsed from local Claude Code journals. The counter resets naturally at the start of each calendar month.
+
+| Level | Monthly tokens |
+| --- | ---: |
+| Lv.1 | 0 - 49,999,999 |
+| Lv.2 | 50,000,000 - 199,999,999 |
+| Lv.3 | 200,000,000 - 499,999,999 |
+| Lv.4 | 500,000,000 - 999,999,999 |
+| Lv.5 | 1,000,000,000+ |
+
+## Characters
+
+| Character | Display name | Menu bar frames | Pet tab frames |
+| --- | --- | ---: | ---: |
+| Seal | 물범 말랑이 | 6 | 6 |
+| Cat | 고양 말랑이 | 2 | 2 |
+
+Selected character, menu bar display mode, refresh interval, notification settings, backoff state, cached plan name, and the latest usage cache are persisted locally.
+
+## Privacy And Security
+
+- ClaudePet reads the same OAuth login that Claude Code stores locally.
+- It does not ask for or store Anthropic API keys.
+- It stores only app preferences and the last successful usage snapshot locally.
+- Local journal parsing stays on your machine.
+- Network traffic is limited to the Anthropic usage and account endpoints listed above.
+- The app is not sandboxed because it needs access to `~/.claude` files and the Claude Code Keychain item.
+
+## Troubleshooting
+
+### No OAuth Token
+
+Run:
+
 ```bash
 claude login
 ```
 
-ClaudePet automatically detects your token from:
-1. `~/.claude/.credentials.json` (primary)
-2. macOS Keychain — service `Claude Code-credentials` (fallback)
+Then open ClaudePet Settings and check whether Authentication shows `Connected`.
 
-If the token is missing or expired, the app shows an error banner with instructions.
+### Rate Limited
 
-> 토큰이 없거나 만료된 경우 앱 내 에러 배너에서 안내를 확인할 수 있습니다.
+Wait for the retry time shown in the popover. Repeated manual refreshes do not bypass the cooldown and can make the upstream rate limit last longer.
 
----
+### Stats Are Empty
 
-## Pet System / 펫 시스템
+Stats require local Claude Code journal files under `~/.claude/projects`. They appear after Claude Code has written assistant usage records.
 
-### Session Conditions / 세션 상태 (5h quota)
+### Cached Usage Looks Stale
 
-| Condition | Usage | Description |
-|-----------|-------|-------------|
-| Idle / 휴식중 | 0–1% | Resting quietly |
-| Calm / 안정적 | 1–20% | Plenty of headroom |
-| Warming Up / 시동중 | 20–40% | Getting into it |
-| Focused / 집중중 | 40–60% | In the zone |
-| Overloaded / 과열직전 | 60–100% | Running hot |
+ClaudePet keeps showing the last successful usage snapshot when the API is unavailable. The popover status indicator turns orange in cached mode.
 
-Animation speed scales with session usage: **4 fps** (idle) → **15 fps** (max).
+## Development Notes
 
-### Pet Levels / 펫 레벨 (monthly tokens from local journals)
+- App entry point: `ClaudePet/ClaudePetApp.swift`
+- Shared state and polling: `ClaudePet/PetManager.swift`
+- OAuth usage/account API client: `ClaudePet/UsageAPIClient.swift`
+- Claude Code token loading: `ClaudePet/AuthLoader.swift`
+- JSONL journal parsing: `ClaudePet/JournalLoader.swift`
+- Menu bar UI: `ClaudePet/MenuBarView.swift`
+- Popover tabs and character picker: `ClaudePet/PopoverView.swift`
+- Analytics UI: `ClaudePet/AnalyticsView.swift`
+- Settings UI: `ClaudePet/SettingsView.swift`
 
-| Level | Monthly Tokens |
-|-------|----------------|
-| Lv.1 | 0 – 50M |
-| Lv.2 | 50M – 200M |
-| Lv.3 | 200M – 500M |
-| Lv.4 | 500M – 1B |
-| Lv.5 | 1B+ |
-
-Token counts are parsed from `~/.claude/projects/**/*.jsonl` (Claude Code session logs) — no API calls needed for this.
-
-> 월간 토큰 수는 로컬 Claude Code 세션 로그(JSONL)에서 파싱합니다. API 호출 없이 계산됩니다.
-
----
-
-## Characters / 캐릭터
-
-| Character | 이름 | Frames |
-|-----------|------|--------|
-| Seal | 물범 말랑이 | 6 frames |
-| Cat | 고양 말랑이 | 2 frames |
-
-Switch characters anytime from the Pet tab. Selection persists across restarts.
-
-> 펫 탭에서 언제든지 캐릭터를 변경할 수 있으며, 재시작 후에도 유지됩니다.
-
----
-
-## How It Works / 동작 원리
-
-**Data sources / 데이터 소스:**
-
-| Source | Used for |
-|--------|----------|
-| `GET /api/oauth/usage` (Anthropic API) | Session %, weekly quotas, Extra Usage |
-| `~/.claude/projects/**/*.jsonl` | Monthly tokens, daily activity, pet level |
-| `GET /api/account` (Anthropic API) | Plan name (cached 24h) |
-
-**Polling behavior / 폴링 동작:**
-- Default refresh: every 5 minutes (configurable)
-- Minimum gap between requests: 60 seconds
-- On HTTP 429: backoff doubles (60s → 120s → … → 1800s max), resets on success
-- Last successful data is cached locally and shown with an orange indicator when stale
-
-**Memory footprint:** ~20–30 MB
-
----
-
-## Tech Stack / 기술 스택
-
-- Swift 5.9+, SwiftUI, AppKit
-- macOS 13+ (Ventura+)
-- Zero external dependencies / 외부 의존성 없음
-- Swift Concurrency (async/await)
-- `LSUIElement = true` — menu bar only, no Dock icon
-
----
-
-## Privacy / 개인정보 처리
-
-- No data leaves your device except the two Anthropic API calls above (using your own OAuth token)
-- Token is read from local file / Keychain — never stored elsewhere by this app
-- JSONL parsing happens entirely locally
-
-> 위 2개의 Anthropic API 호출 외에는 어떠한 데이터도 외부로 전송되지 않습니다. JSONL 파싱은 로컬에서만 이루어집니다.
-
----
-
-## Acknowledgements / 참고
-
-- [Claude God](https://github.com/Lcharvol/Claude-God) (MIT) — OAuth API integration patterns
-- [TokenEater](https://github.com/AThevon/TokenEater) (MIT) — lightweight architecture reference
-- [RunCat](https://kyome.io/runcat/) — menu bar animation concept
-
----
+The project has no external package dependencies and currently has no XCTest target.
 
 ## License
 
-MIT — see [LICENSE](LICENSE)
+MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Refresh `README.md` as the English implementation-aligned README.
- Add `README.ko.md` as a Korean version with the same structure and current behavior.
- Add language links between the English and Korean README files.

## Validation

- Ran `git diff --check` for Markdown whitespace validation.
- Documentation-only change, so the app build was not run.